### PR TITLE
[refactor] Introduce WebviewBuilder

### DIFF
--- a/core/src/main/java/io/avaje/webview/AWTWebview.java
+++ b/core/src/main/java/io/avaje/webview/AWTWebview.java
@@ -1,5 +1,8 @@
 package io.avaje.webview;
 
+import com.sun.jna.Native;
+import com.sun.jna.ptr.PointerByReference;
+
 import java.awt.*;
 import java.io.Closeable;
 import java.util.function.Consumer;
@@ -65,7 +68,9 @@ public class AWTWebview extends Canvas implements Closeable {
 
             // We need to create the webview off of the swing thread.
             Thread t = new Thread(() -> {
-                this.webview = new Webview(this.debug, this);
+                var ptr = new PointerByReference(Native.getComponentPointer(this));
+                this.webview = Webview.builder().debug(this.debug).windowPointer(ptr).build();
+                // this.webview = new Webview(this.debug, this);
 
                 this.updateSize();
 

--- a/core/src/main/java/io/avaje/webview/Webview.java
+++ b/core/src/main/java/io/avaje/webview/Webview.java
@@ -24,111 +24,110 @@
 package io.avaje.webview;
 
 import io.avaje.webview.platform.Platform;
-import com.sun.jna.Native;
 import com.sun.jna.ptr.PointerByReference;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import java.awt.*;
 import java.io.Closeable;
 
 import static io.avaje.webview.WebviewNative.*;
 
-public class Webview implements Closeable, Runnable {
+public final class Webview implements Closeable, Runnable {
 
+    private final WebviewNative N;
     private final long $pointer;
 
-    /**
-     * Creates a new Webview. <br/>
-     * The default size will be set, and if the size is set again before loading the
-     * URL, a splash will appear.<br/>
-     * eg:
-     * 
-     * <pre>
-     * <code>
-     *   WebView wv = new WebView(true);
-     *   wv.setSize(1280, 720);
-     *   wv.loadURL("...")
-     * </code>
-     * </pre>
-     * 
-     * It's recommended that setting size together:
-     * 
-     * <pre>
-     * <code>
-     *   WebView wv = new WebView(true, 1280, 720);
-     *   wv.loadURL("...")
-     * </code>
-     * </pre>
-     * 
-     * @param debug Enables devtools/inspect element if true.
-     * 
-     * @see         #Webview(boolean, int, int)
-     */
-    public Webview(boolean debug) {
-        this(debug, (PointerByReference) null);
+    public static WebviewBuilder builder() {
+        return new WebviewBuilder();
     }
 
-    /**
-     * Creates a new Webview.
-     *
-     * @param debug  Enables devtools/inspect element if true.
-     * @param width  preset - width
-     * @param height preset - height
-     */
-    public Webview(boolean debug, int width, int height) {
-        this(debug, null, width, height);
-    }
+//    /**
+//     * Creates a new Webview. <br/>
+//     * The default size will be set, and if the size is set again before loading the
+//     * URL, a splash will appear.<br/>
+//     * eg:
+//     *
+//     * <pre>
+//     * <code>
+//     *   WebView wv = new WebView(true);
+//     *   wv.setSize(1280, 720);
+//     *   wv.loadURL("...")
+//     * </code>
+//     * </pre>
+//     *
+//     * It's recommended that setting size together:
+//     *
+//     * <pre>
+//     * <code>
+//     *   WebView wv = new WebView(true, 1280, 720);
+//     *   wv.loadURL("...")
+//     * </code>
+//     * </pre>
+//     *
+//     * @param debug Enables devtools/inspect element if true.
+//     *
+//     * @see         #Webview(boolean, int, int)
+//     */
+//    public Webview(boolean debug) {
+//        this(debug, (PointerByReference) null);
+//    }
+//
+//    /**
+//     * Creates a new Webview.
+//     *
+//     * @param debug  Enables devtools/inspect element if true.
+//     * @param width  preset - width
+//     * @param height preset - height
+//     */
+//    public Webview(boolean debug, int width, int height) {
+//        this(debug, null, width, height);
+//    }
+//
+//    /**
+//     * Creates a new Webview. <br/>
+//     * The default size will be set, and if the size is set again before loading the
+//     * URL, a splash will appear.<br/>
+//     * eg:
+//     *
+//     * <pre>
+//     * <code>
+//     *   WebView wv = new WebView(true);
+//     *   wv.setSize(1280, 720);
+//     *   wv.loadURL("...")
+//     * </code>
+//     * </pre>
+//     *
+//     * It's recommended that setting size together:
+//     *
+//     * <pre>
+//     * <code>
+//     *   WebView wv = new WebView(true, 1280, 720);
+//     *   wv.loadURL("...")
+//     * </code>
+//     * </pre>
+//     *
+//     * @param debug  Enables devtools/inspect element if true.
+//     *
+//     * @param target The target awt component, such as a {@link java.awt.JFrame} or
+//     *               {@link java.awt.Canvas}. Must be "drawable".
+//     *
+//     * @see          #Webview(boolean, PointerByReference, int, int)
+//     */
+//    public Webview(boolean debug, @NonNull Component target) {
+//        this(debug, new PointerByReference(Native.getComponentPointer(target)));
+//    }
+//
+//    /**
+//     * @deprecated Use this only if you absolutely know what you're doing.
+//     */
+//    @Deprecated
+//    public Webview(boolean debug, @Nullable PointerByReference windowPointer) {
+//        this(debug, windowPointer, 800, 600);
+//    }
 
-    /**
-     * Creates a new Webview. <br/>
-     * The default size will be set, and if the size is set again before loading the
-     * URL, a splash will appear.<br/>
-     * eg:
-     * 
-     * <pre>
-     * <code>
-     *   WebView wv = new WebView(true);
-     *   wv.setSize(1280, 720);
-     *   wv.loadURL("...")
-     * </code>
-     * </pre>
-     * 
-     * It's recommended that setting size together:
-     * 
-     * <pre>
-     * <code>
-     *   WebView wv = new WebView(true, 1280, 720);
-     *   wv.loadURL("...")
-     * </code>
-     * </pre>
-     * 
-     * @param debug  Enables devtools/inspect element if true.
-     * 
-     * @param target The target awt component, such as a {@link java.awt.JFrame} or
-     *               {@link java.awt.Canvas}. Must be "drawable".
-     * 
-     * @see          #Webview(boolean, PointerByReference, int, int)
-     */
-    public Webview(boolean debug, @NonNull Component target) {
-        this(debug, new PointerByReference(Native.getComponentPointer(target)));
-    }
-
-    /**
-     * @deprecated Use this only if you absolutely know what you're doing.
-     */
-    @Deprecated
-    public Webview(boolean debug, @Nullable PointerByReference windowPointer) {
-        this(debug, windowPointer, 800, 600);
-    }
-
-    /**
-     * @deprecated Use this only if you absolutely know what you're doing.
-     */
-    @Deprecated
-    public Webview(boolean debug, @Nullable PointerByReference windowPointer, int width, int height) {
-        $pointer = N.webview_create(debug, windowPointer);
-
+    Webview(WebviewNative n, boolean debug, @Nullable PointerByReference windowPointer, int width, int height) {
+        this.N = n;
+        this.$pointer = N.webview_create(debug, windowPointer);
         this.loadURL(null);
         this.setSize(width, height);
     }
@@ -343,7 +342,7 @@ public class Webview implements Closeable, Runnable {
         }
     }
 
-    public static String getVersion() {
+    public String getVersion() {
         byte[] bytes = N.webview_version().version_number;
         int length = 0;
         for (byte b : bytes) {

--- a/core/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/core/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -2,6 +2,7 @@ package io.avaje.webview;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.ptr.PointerByReference;
 import io.avaje.webview.platform.LinuxLibC;
 import io.avaje.webview.platform.Platform;
 import org.jspecify.annotations.NonNull;
@@ -11,15 +12,97 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
-final class Bootstrap {
+public final class WebviewBuilder {
 
-    static WebviewNative runSetup() {
+    private static WebviewNative NATIVE_LIB;
+
+    private boolean useTempDirectory;
+    private String title;
+    private boolean debug;
+    private PointerByReference windowPointer;
+    private int width = 800;
+    private int height = 600;
+    private String html;
+    private String url;
+
+    WebviewBuilder() {
+
+    }
+
+    public static WebviewBuilder builder() {
+        return new WebviewBuilder();
+    }
+
+    public WebviewBuilder useTempDirectory(boolean useTempDirectory) {
+        this.useTempDirectory = useTempDirectory;
+        return this;
+    }
+
+    public WebviewBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public WebviewBuilder debug(boolean debug) {
+        this.debug = debug;
+        return this;
+    }
+
+    public WebviewBuilder windowPointer(PointerByReference windowPointer) {
+        this.windowPointer = windowPointer;
+        return this;
+    }
+
+    public WebviewBuilder width(int width) {
+        this.width = width;
+        return this;
+    }
+
+    public WebviewBuilder height(int height) {
+        this.height = height;
+        return this;
+    }
+
+    public WebviewBuilder html(String html) {
+        this.html = html;
+        return this;
+    }
+
+    public WebviewBuilder url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public Webview build() {
+        var n = initNative(this);
+        var view = new Webview(n, debug, windowPointer, width, height);
+        if (title != null) {
+            view.setTitle(title);
+        }
+        if (url != null) {
+            view.loadURL(url);
+        } else if (html != null) {
+            view.setHTML(html);
+        }
+        return view;
+    }
+
+    private synchronized WebviewNative initNative(WebviewBuilder bootstrap) {
+        if (NATIVE_LIB == null) {
+            NATIVE_LIB = bootstrap.initNativeLibrary();
+        }
+        return NATIVE_LIB;
+    }
+
+
+    private WebviewNative initNativeLibrary() {
         // Extract all of the libs.
         for (String lib : platformLibraries()) {
-            File target = new File(new File(lib).getName());
+            File target = createTarget(lib);
             if (target.exists()) {
                 target.delete();
             }
+            System.out.println("target: " + target.getAbsolutePath());
             target.deleteOnExit();
 
             if (extractToFile(lib, target)) {
@@ -28,13 +111,25 @@ final class Bootstrap {
             }
         }
 
-        System.setProperty("jna.library.path", ".");
+        // System.setProperty("jna.library.path", ".");
 
         return Native.load(
                 "webview",
                 WebviewNative.class,
                 Collections.singletonMap(Library.OPTION_STRING_ENCODING, "UTF-8")
         );
+    }
+
+    private File createTarget(String lib) {
+        var name = new File(lib).getName();
+        if (useTempDirectory) {
+            try {
+                return File.createTempFile("webview-", "-" + name);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return new File(name);
     }
 
     private static List<String> platformLibraries() {

--- a/core/src/main/java/io/avaje/webview/WebviewNative.java
+++ b/core/src/main/java/io/avaje/webview/WebviewNative.java
@@ -34,7 +34,9 @@ import java.util.List;
 
 interface WebviewNative extends Library {
 
-    WebviewNative N = Bootstrap.runSetup();
+    static WebviewBuilder builder() {
+        return new WebviewBuilder();
+    }
 
     int WV_HINT_NONE = 0;
     int WV_HINT_MIN = 1;


### PR DESCRIPTION
- Change Bootstrap to a Builder (to have control over bootstrapping such as use of temporary files for extracting libs
- Replace the Webview constructors with the builder
- Builder will only initialise the Native library once