### PR TITLE
[example] Fix htmx-jex-bootstrap example for native image, add resource-config.json

### DIFF
--- a/examples/htmx-jex-bootstrap/src/main/resources/META-INF/native-image/resource-config.json
+++ b/examples/htmx-jex-bootstrap/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "pattern": "static/*.*"
+    }
+  ]
+}


### PR DESCRIPTION
Note that in the next version of Jex this will not be necessary for this case, as avaje-jex-static-content will include this resource pattern (for native-image) so that resources in /static will "just work" out of the box.