### PR TITLE
module java.desktop is requires static (optional)

### DIFF
--- a/avaje-webview/src/main/java/module-info.java
+++ b/avaje-webview/src/main/java/module-info.java
@@ -2,7 +2,7 @@
 module io.avaje.webview {
 
   requires org.jspecify;
-  requires java.desktop;
+  requires static java.desktop;
 
   exports io.avaje.webview;
 


### PR DESCRIPTION
We don't need to use AWT etc to use the Webview
(and imo most users will not but just use it in
its own window)