### PR TITLE
Amend copyright in `license`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
 Copyright (c) 2026 avaje
+Copyright (c) 2024 Alex Bowles @ Casterlabs
+Copyright (c) 2017 Serge Zaitsev
+Copyright (c) 2022 Steffen André Langnes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It's up to you, but the MIT license requires the copyright and full license files being included (though this seems like it has diverged enough from the original anyway). Since you chose to keep MIT it's just a choice of adding credit or not.

EDIT - you also have kept file headers in some files

Signed-off-by: Mahied Maruf <contact@mechite.com>