### PR TITLE
[examples] Add native image profile build option to examples / hello-world-jex

### DIFF
--- a/examples/hello-world-jex/pom.xml
+++ b/examples/hello-world-jex/pom.xml
@@ -66,4 +66,43 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>native</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.11.3</version>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>compile-no-fork</goal>
+								</goals>
+								<phase>package</phase>
+								<configuration>
+									<mainClass>example.Main</mainClass>
+									<jvmArgs>
+										<jvmArg>--enable-native-access=ALL-UNNAMED</jvmArg>
+									</jvmArgs>
+									<buildArgs>
+										<buildArg>-Ob</buildArg> <!-- fast build -->
+										<buildArg>-R:MaxHeapSize=200m</buildArg>
+										<buildArg>--emit build-report</buildArg>
+										<buildArg>--no-fallback</buildArg>
+										<buildArg>--allow-incomplete-classpath</buildArg>
+										<buildArg>-march=compatibility</buildArg>
+									</buildArgs>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Noting that this native image doesn't actually run

```
❯ ./target/hello-world-jex 
Jan 14, 2026 1:33:36 PM io.avaje.jex.core.ServiceManager$Builder initJsonService
WARNING: No Json library configured
Jan 14, 2026 1:33:36 PM io.avaje.jex.core.BootstrapServer start
INFO: Avaje Jex started class sun.net.httpserver.HttpServerImpl in 8ms on http://0:0:0:0:0:0:0:0:59388
Exception in thread "main" java.lang.RuntimeException: Failed to create callback handle
        at io.avaje.webview.DWebView.createBindCallbackHandle(DWebView.java:272)
        at io.avaje.webview.DWebView.bindCallback(DWebView.java:258)
        at io.avaje.webview.DWebView.lambda$bind$0(DWebView.java:230)
        at io.avaje.webview.DWebView.handleDispatch(DWebView.java:131)
        at io.avaje.webview.DWebView.bind(DWebView.java:230)
        at example.Main.main(Main.java:65)
        at java.base@25.0.1/java.lang.invoke.LambdaForm$DMH/s4b9cede1.invokeStaticInit(LambdaForm$DMH)
Caused by: java.lang.NoSuchMethodException: no such method: io.avaje.webview.DWebView$$Lambda/0xe9b070c77af8f6974af5006ae8e3805c0.invoke(long,MemorySegment)void/invokeSpecial
        at java.base@25.0.1/java.lang.invoke.MemberName.makeAccessException(MemberName.java:910)
        at java.base@25.0.1/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:989)
        at java.base@25.0.1/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3591)
        at java.base@25.0.1/java.lang.invoke.MethodHandles$Lookup.bind(MethodHandles.java:3215)
        at io.avaje.webview.DWebView.createBindCallbackHandle(DWebView.java:266)
        ... 6 more
Caused by: java.lang.NoSuchMethodError: io.avaje.webview.DWebView$$Lambda/0xe9b070c77af8f6974af5006ae8e3805c0.invoke(long, java.lang.foreign.MemorySegment)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.Util_java_lang_invoke_MethodHandleNatives.resolve(Target_java_lang_invoke_MethodHandleNatives.java:352)
        at java.base@25.0.1/java.lang.invoke.MethodHandleNatives.resolve(MethodHandleNatives.java:208)
        at java.base@25.0.1/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:120)
        at java.base@25.0.1/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:986)
        ... 9 more
```