### PR TITLE
remove eval from start tasks

### DIFF
--- a/avaje-webview/src/main/java/io/avaje/webview/DWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/DWebView.java
@@ -220,10 +220,6 @@ final class DWebView implements Webview {
 
   @Override
   public void eval(@NonNull String script) {
-    if (!running) {
-      startTasks.add(() -> eval(script));
-      return;
-    }
     dispatch(
         () -> {
           WebviewNative.webview_eval(


### PR DESCRIPTION
Apparently, if you just have init script it works. What a strange issue