### PR TITLE
Add Borderless and Draggable Windows

### DIFF
--- a/avaje-webview/src/main/java/io/avaje/webview/Webview.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/Webview.java
@@ -203,6 +203,22 @@ public interface Webview extends Closeable, Runnable {
   Webview fullscreen();
 
   /**
+   * Begins a native window-move operation, as if the user had grabbed the title bar and started
+   * dragging.
+   *
+   * <p>Call this from a binding invoked on {@code mousedown} over a custom draggable area (e.g. a
+   * custom title bar) to make that area drag the window.
+   *
+   * <pre>{@code
+   * webview.bind("startDrag", req -> {
+   *   webview.startWindowDrag();
+   *   return null;
+   * });
+   * }</pre>
+   */
+  void startWindowDrag();
+
+  /**
    * Sets the icon for the webview window
    *
    * @param path to the icon file
@@ -282,6 +298,18 @@ public interface Webview extends Closeable, Runnable {
      * @return this builder
      */
     Builder navigate(String url);
+
+    /**
+     * Creates the window without native OS decorations (title bar, borders, and minimize/maximize/
+     * close buttons). Defaults to {@code false}. The window remains resizable via its edges.
+     *
+     * <p>Combine with {@link Webview#startWindowDrag()} to implement a custom draggable title bar,
+     * since a borderless window has no native title bar for the user to grab.
+     *
+     * @param borderless {@code true} to remove native window decorations
+     * @return this builder
+     */
+    Builder borderless(boolean borderless);
 
     /**
      * Builds a Webview using the configuration

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -195,6 +195,11 @@ public abstract sealed class WebviewBase implements Webview
   public abstract Webview fullscreen();
 
   @Override
+  public void startWindowDrag() {
+    dispatchImpl(this::startWindowDragImpl);
+  }
+
+  @Override
   public abstract void setIcon(Path path);
 
   @Override
@@ -243,6 +248,8 @@ public abstract sealed class WebviewBase implements Webview
   protected abstract void setFixedSizeImpl(int width, int height);
 
   protected abstract void setHtmlImpl(String html);
+
+  protected abstract void startWindowDragImpl();
 
   protected abstract void evalImpl(String js);
 

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -53,10 +53,29 @@ public abstract sealed class WebviewBase implements Webview
       })();
       """;
 
-  private final boolean redirectConsole;
+  private static final String APP_REGION_DRAG_JS =
+      """
+      (function() {
+        'use strict';
+        document.addEventListener('mousedown', function(e) {
+          if (e.button !== 0) return;
+          var el = e.target;
+          while (el instanceof HTMLElement) {
+            var r = window.getComputedStyle(el).getPropertyValue('-webkit-app-region');
+            if (r === 'no-drag') return;
+            if (r === 'drag') { e.preventDefault(); __avaje_wv_drag__(); return; }
+            el = el.parentElement;
+          }
+        });
+      })();
+      """;
 
-  protected WebviewBase(boolean redirectConsole) {
+  private final boolean redirectConsole;
+  protected final boolean borderless;
+
+  protected WebviewBase(boolean redirectConsole, boolean borderless) {
     this.redirectConsole = redirectConsole;
+    this.borderless = borderless;
   }
 
   // JS bridge state, all mutations to userScripts/bindScriptIdx must happen on the main thread
@@ -78,6 +97,17 @@ public abstract sealed class WebviewBase implements Webview
     userScripts.add(emptyBind);
     nativeAddUserScript(emptyBind);
     if (redirectConsole) redirectConsole();
+    if (borderless) setupAppRegionDrag();
+  }
+
+  private void setupAppRegionDrag() {
+    bind(
+        "__avaje_wv_drag__",
+        req -> {
+          startWindowDragImpl();
+          return "null";
+        });
+    addUserScriptInternal(APP_REGION_DRAG_JS);
   }
 
   /**
@@ -96,18 +126,20 @@ public abstract sealed class WebviewBase implements Webview
 
   @Override
   public void setHTML(@Nullable String html) {
-    dispatchImpl(() -> {
-      syncBindScript();
-      setHtmlImpl(html != null ? html : "");
-    });
+    dispatchImpl(
+        () -> {
+          syncBindScript();
+          setHtmlImpl(html != null ? html : "");
+        });
   }
 
   @Override
   public void navigate(@Nullable String url) {
-    dispatchImpl(() -> {
-      syncBindScript();
-      navigateImpl(url == null ? "about:blank" : url);
-    });
+    dispatchImpl(
+        () -> {
+          syncBindScript();
+          navigateImpl(url == null ? "about:blank" : url);
+        });
   }
 
   @Override
@@ -157,7 +189,12 @@ public abstract sealed class WebviewBase implements Webview
     dispatchImpl(
         () -> {
           rebuildBindScript();
-          evalImpl("if(window.__webview__&&!window.hasOwnProperty(" + jsonEscape(name) + "))window.__webview__.onBind(" + jsonEscape(name) + ")");
+          evalImpl(
+              "if (window.__webview__ && !window.hasOwnProperty("
+                  + jsonEscape(name)
+                  + ")) window.__webview__.onBind("
+                  + jsonEscape(name)
+                  + ")");
         });
   }
 
@@ -167,7 +204,7 @@ public abstract sealed class WebviewBase implements Webview
     dispatchImpl(
         () -> {
           rebuildBindScript();
-          evalImpl("if(window.__webview__)window.__webview__.onUnbind(" + jsonEscape(name) + ")");
+          evalImpl("if (window.__webview__) window.__webview__.onUnbind(" + jsonEscape(name) + ")");
         });
   }
 
@@ -272,7 +309,7 @@ public abstract sealed class WebviewBase implements Webview
   void returnResult(String id, int status, String result) {
     final var escaped = result == null || result.isEmpty() ? "undefined" : jsonEscape(result);
     final var js =
-        "window.__webview__.onReply(" + jsonEscape(id) + "," + status + "," + escaped + ")";
+        "window.__webview__.onReply(" + jsonEscape(id) + ", " + status + ", " + escaped + ")";
     dispatchImpl(() -> evalImpl(js));
   }
 
@@ -438,63 +475,68 @@ public abstract sealed class WebviewBase implements Webview
    * @return the complete, minified bridge script ready for injection as a user script
    */
   private static String buildInitScript(String postFn) {
-    return "(function(){'use strict';"
-        + "function generateId(){"
-        + "var crypto=window.crypto||window.msCrypto;"
-        + "var bytes=new Uint8Array(16);"
-        + "crypto.getRandomValues(bytes);"
-        + "return Array.prototype.slice.call(bytes).map(function(n){"
-        + "var s=n.toString(16);"
-        + "return((s.length%2)==1?'0':'')+s;"
-        + "}).join('');"
-        + "}"
-        + "var Webview=(function(){"
-        + "var _promises={};"
-        + "function Webview_(){}"
-        + "Webview_.prototype.post=function(message){return("
-        + postFn
-        + ")(message);};"
-        + "Webview_.prototype.call=function(method){"
-        + "var _id=generateId();"
-        + "var _params=Array.prototype.slice.call(arguments,1);"
-        + "var promise=new Promise(function(resolve,reject){_promises[_id]={resolve,reject};});"
-        + "this.post(JSON.stringify({id:_id,method:method,params:_params}));"
-        + "return promise;"
-        + "};"
-        + "Webview_.prototype.onReply=function(id,status,result){"
-        + "var promise=_promises[id];"
-        + "if(result!==undefined){"
-        + "try{result=JSON.parse(result);}"
-        + "catch(e){promise.reject(new Error('Failed to parse binding result as JSON'));return;}"
-        + "}"
-        + "if(status===0){promise.resolve(result);}else{promise.reject(result);}"
-        + "};"
-        + "Webview_.prototype.onBind=function(name){"
-        + "if(window.hasOwnProperty(name))throw new Error('Property \"'+name+'\" already exists');"
-        + "window[name]=(function(){"
-        + "var params=[name].concat(Array.prototype.slice.call(arguments));"
-        + "return Webview_.prototype.call.apply(this,params);"
-        + "}).bind(this);"
-        + "};"
-        + "Webview_.prototype.onUnbind=function(name){"
-        + "if(!window.hasOwnProperty(name))throw new Error('Property \"'+name+'\" does not exist');"
-        + "delete window[name];"
-        + "};"
-        + "return Webview_;"
-        + "})();"
-        + "window.__webview__=new Webview();"
-        + "})()";
+    return String.format(
+        """
+        (function() {
+          'use strict';
+          function generateId() {
+            var crypto = window.crypto || window.msCrypto;
+            var bytes = new Uint8Array(16);
+            crypto.getRandomValues(bytes);
+            return Array.prototype.slice.call(bytes).map(function(n) {
+              var s = n.toString(16);
+              return ((s.length %% 2) == 1 ? '0' : '') + s;
+            }).join('');
+          }
+          var Webview = (function() {
+            var _promises = {};
+            function Webview_() {}
+            Webview_.prototype.post = function(message) {
+              return (%s)(message);
+            };
+            Webview_.prototype.call = function(method) {
+              var _id = generateId();
+              var _params = Array.prototype.slice.call(arguments, 1);
+              var promise = new Promise(function(resolve, reject) { _promises[_id] = { resolve, reject }; });
+              this.post(JSON.stringify({ id: _id, method: method, params: _params }));
+              return promise;
+            };
+            Webview_.prototype.onReply = function(id, status, result) {
+              var promise = _promises[id];
+              if (result !== undefined) {
+                try { result = JSON.parse(result); }
+                catch (e) { promise.reject(new Error('Failed to parse binding result as JSON')); return; }
+              }
+              if (status === 0) { promise.resolve(result); } else { promise.reject(result); }
+            };
+            Webview_.prototype.onBind = function(name) {
+              if (window.hasOwnProperty(name)) throw new Error('Property "' + name + '" already exists');
+              window[name] = (function() {
+                var params = [name].concat(Array.prototype.slice.call(arguments));
+                return Webview_.prototype.call.apply(this, params);
+              }).bind(this);
+            };
+            Webview_.prototype.onUnbind = function(name) {
+              if (!window.hasOwnProperty(name)) throw new Error('Property "' + name + '" does not exist');
+              delete window[name];
+            };
+            return Webview_;
+          })();
+          window.__webview__ = new Webview();
+        })()
+        """,
+        postFn);
   }
 
   private String buildBindScript() {
-    final var sb = new StringBuilder("(function(){'use strict';var methods=[");
+    final var sb = new StringBuilder("(function() {'use strict';  var methods = [");
     var first = true;
     for (final String name : bindings.keySet()) {
-      if (!first) sb.append(",");
+      if (!first) sb.append(", ");
       sb.append(jsonEscape(name));
       first = false;
     }
-    sb.append("];methods.forEach(function(n){window.__webview__.onBind(n);});})()");
+    sb.append("];\n  methods.forEach(function(n) { window.__webview__.onBind(n); });\n})()");
     return sb.toString();
   }
 

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -97,7 +97,7 @@ public abstract sealed class WebviewBase implements Webview
     userScripts.add(emptyBind);
     nativeAddUserScript(emptyBind);
     if (redirectConsole) redirectConsole();
-    if (borderless) setupAppRegionDrag();
+    if (borderless && this instanceof Win32WebView) setupAppRegionDrag();
   }
 
   private void setupAppRegionDrag() {

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -16,6 +16,7 @@ final class WebviewBuilder implements Builder {
   private int height = 600;
   private String html;
   private String url;
+  private boolean borderless;
 
   WebviewBuilder() {}
 
@@ -67,6 +68,12 @@ final class WebviewBuilder implements Builder {
   }
 
   @Override
+  public WebviewBuilder borderless(boolean borderless) {
+    this.borderless = borderless;
+    return this;
+  }
+
+  @Override
   public Webview build() {
     final var view = createForPlatform();
     if (title != null) view.setTitle(title);
@@ -82,9 +89,12 @@ final class WebviewBuilder implements Builder {
 
   private Webview createForPlatform() {
     final var os = System.getProperty("os.name", "").toLowerCase();
-    if (os.contains("linux")) return new GtkWebView(enableDeveloperTools, redirectConsole, width, height);
-    if (os.contains("mac")) return new CocoaWebView(enableDeveloperTools, redirectConsole, width, height);
-    if (os.contains("win")) return new Win32WebView(enableDeveloperTools, redirectConsole, width, height);
+    if (os.contains("win"))
+      return new Win32WebView(enableDeveloperTools, redirectConsole, width, height, borderless);
+    if (os.contains("mac"))
+      return new CocoaWebView(enableDeveloperTools, redirectConsole, width, height, borderless);
+    if (os.contains("linux"))
+      return new GtkWebView(enableDeveloperTools, redirectConsole, width, height, borderless);
     throw new UnsupportedOperationException(
         "Unsupported platform: " + System.getProperty("os.name"));
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
@@ -1,6 +1,7 @@
 package io.avaje.webview.linux;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
@@ -127,6 +128,59 @@ final class Gtk4 {
    */
   private static final MethodHandle GTK_WINDOW_FULLSCREEN =
       downcall("gtk_window_fullscreen", FunctionDescriptor.ofVoid(ADDRESS));
+
+  /**
+   * {@code gtk_window_set_decorated(GtkWindow* window, gboolean setting) -> void}
+   *
+   * <p>Controls whether the window manager draws native decorations (title bar, borders,
+   * minimize/maximize/close buttons) around the window.
+   */
+  private static final MethodHandle GTK_WINDOW_SET_DECORATED =
+      downcall("gtk_window_set_decorated", FunctionDescriptor.ofVoid(ADDRESS, JAVA_INT));
+
+  /**
+   * {@code gtk_native_get_surface(GtkNative* self) -> GdkSurface*}
+   *
+   * <p>Every realized top-level {@code GtkWindow} implements {@code GtkNative}; this returns its
+   * backing {@code GdkSurface}, which also implements the {@code GdkToplevel} interface used by
+   * {@link #GDK_TOPLEVEL_BEGIN_MOVE}.
+   */
+  private static final MethodHandle GTK_NATIVE_GET_SURFACE =
+      downcall("gtk_native_get_surface", FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+  /** {@code gtk_widget_get_display(GtkWidget* widget) -> GdkDisplay*} */
+  private static final MethodHandle GTK_WIDGET_GET_DISPLAY =
+      downcall("gtk_widget_get_display", FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+  /** {@code gdk_display_get_default_seat(GdkDisplay* display) -> GdkSeat*} */
+  private static final MethodHandle GDK_DISPLAY_GET_DEFAULT_SEAT =
+      downcall("gdk_display_get_default_seat", FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+  /** {@code gdk_seat_get_pointer(GdkSeat* seat) -> GdkDevice*} */
+  private static final MethodHandle GDK_SEAT_GET_POINTER =
+      downcall("gdk_seat_get_pointer", FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+  /**
+   * {@code gdk_surface_get_device_position(GdkSurface*, GdkDevice*, double* x, double* y,
+   * GdkModifierType* mask) -> gboolean}
+   */
+  private static final MethodHandle GDK_SURFACE_GET_DEVICE_POSITION =
+      downcall(
+          "gdk_surface_get_device_position",
+          FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+  /**
+   * {@code gdk_toplevel_begin_move(GdkToplevel*, GdkDevice*, int button, double x, double y,
+   * guint32 timestamp) -> void}
+   *
+   * <p>Asks the window manager/compositor to begin an interactive window-move grab, as if the user
+   * had pressed {@code button} at surface position {@code (x, y)} and started dragging.
+   */
+  private static final MethodHandle GDK_TOPLEVEL_BEGIN_MOVE =
+      downcall(
+          "gdk_toplevel_begin_move",
+          FunctionDescriptor.ofVoid(
+              ADDRESS, ADDRESS, JAVA_INT, JAVA_DOUBLE, JAVA_DOUBLE, JAVA_INT));
 
   /**
    * {@code gtk_widget_set_visible(GtkWidget* widget, gboolean visible) -> void}
@@ -321,6 +375,51 @@ final class Gtk4 {
   static void gtkWindowFullscreen(MemorySegment window) {
     try {
       GTK_WINDOW_FULLSCREEN.invokeExact(window);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Shows or hides native window decorations (title bar, borders, min/max/close buttons).
+   *
+   * @param window a {@code GtkWindow*}
+   * @param decorated {@code false} to remove native decorations
+   */
+  static void gtkWindowSetDecorated(MemorySegment window, boolean decorated) {
+    try {
+      GTK_WINDOW_SET_DECORATED.invokeExact(window, decorated ? 1 : 0);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Begins a native window-move grab on {@code window}'s toplevel surface, using the default seat's
+   * current pointer position as the drag origin and {@code GDK_CURRENT_TIME} (0) as the timestamp,
+   * since the triggering click was consumed by an unrelated JS event rather than a live GDK event
+   * we can forward.
+   *
+   * @param window a realized {@code GtkWindow*}
+   */
+  static void gtkWindowBeginMoveDrag(MemorySegment window) {
+    try (var a = Arena.ofConfined()) {
+      final var surface = (MemorySegment) GTK_NATIVE_GET_SURFACE.invokeExact(window);
+      if (surface.address() == 0L) return;
+      final var display = (MemorySegment) GTK_WIDGET_GET_DISPLAY.invokeExact(window);
+      final var seat = (MemorySegment) GDK_DISPLAY_GET_DEFAULT_SEAT.invokeExact(display);
+      final var pointer = (MemorySegment) GDK_SEAT_GET_POINTER.invokeExact(seat);
+      final var x = a.allocate(JAVA_DOUBLE);
+      final var y = a.allocate(JAVA_DOUBLE);
+      final var mask = a.allocate(JAVA_INT);
+      final var _ = (int) GDK_SURFACE_GET_DEVICE_POSITION.invokeExact(surface, pointer, x, y, mask);
+      GDK_TOPLEVEL_BEGIN_MOVE.invokeExact(
+          surface,
+          pointer,
+          1 /* GDK_BUTTON_PRIMARY */,
+          x.get(JAVA_DOUBLE, 0),
+          y.get(JAVA_DOUBLE, 0),
+          0 /* GDK_CURRENT_TIME */);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -75,11 +75,14 @@ public final class GtkWebView extends WebviewBase {
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
   private final int initialWidth;
   private final int initialHeight;
+  private final boolean borderless;
 
-  public GtkWebView(boolean debug, boolean redirectConsole, int width, int height) {
+  public GtkWebView(
+      boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
     super(redirectConsole);
     this.initialWidth = width;
     this.initialHeight = height;
+    this.borderless = borderless;
     openWindows.incrementAndGet();
 
     if (gtkThread == null || gtkThread == Thread.currentThread()) {
@@ -299,6 +302,11 @@ public final class GtkWebView extends WebviewBase {
   }
 
   @Override
+  protected void startWindowDragImpl() {
+    LinuxHelper.startWindowDrag(this);
+  }
+
+  @Override
   public void setIcon(Path path) {
     // GTK4 dropped file-based window icons; app icons are set via the .desktop file.
     // gtk_window_set_icon_name() works with icon themes, not arbitrary paths.
@@ -447,6 +455,7 @@ public final class GtkWebView extends WebviewBase {
 
   private void initWindowAndWebView(boolean debug) {
     window = Gtk4.gtkWindowNew();
+    if (borderless) Gtk4.gtkWindowSetDecorated(window, false);
     GLib.gSignalConnect(window, "destroy", destroyStub, MemorySegment.NULL);
 
     webView = WebKit6.webkitWebViewNew();

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -75,14 +75,11 @@ public final class GtkWebView extends WebviewBase {
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
   private final int initialWidth;
   private final int initialHeight;
-  private final boolean borderless;
-
   public GtkWebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
-    super(redirectConsole);
+    super(redirectConsole, borderless);
     this.initialWidth = width;
     this.initialHeight = height;
-    this.borderless = borderless;
     openWindows.incrementAndGet();
 
     if (gtkThread == null || gtkThread == Thread.currentThread()) {

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
@@ -20,6 +20,11 @@ final class LinuxHelper {
     Gtk4.gtkWindowMaximize(webview.nativeWindowPointer());
   }
 
+  /** Begins a native window-move grab, as if the user had grabbed the title bar. */
+  static void startWindowDrag(Webview webview) {
+    Gtk4.gtkWindowBeginMoveDrag(webview.nativeWindowPointer());
+  }
+
   /**
    * Applies a dark or light appearance to all GTK windows in this process.
    *

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -31,7 +31,6 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -158,9 +157,12 @@ public final class CocoaWebView extends WebviewBase {
   // C function pointer (upcall stub) passed to dispatch_async_f to drain the pending queue
   private MemorySegment drainStub;
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
+  private final boolean borderless;
 
-  public CocoaWebView(boolean debug, boolean redirectConsole, int width, int height) {
+  public CocoaWebView(
+      boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
     super(redirectConsole);
+    this.borderless = borderless;
     openWindows.incrementAndGet();
     buildDrainStub();
 
@@ -395,6 +397,11 @@ public final class CocoaWebView extends WebviewBase {
   }
 
   @Override
+  protected void startWindowDragImpl() {
+    MacOSHelper.startWindowDrag(nsWindow);
+  }
+
+  @Override
   public void setIcon(Path path) {
     dispatchImpl(() -> MacOSHelper.setIcon(path));
   }
@@ -606,7 +613,7 @@ public final class CocoaWebView extends WebviewBase {
                   0d,
                   (double) width,
                   (double) height,
-                  NS_STANDARD_WINDOW_MASK,
+                  borderless ? NS_RESIZABLE : NS_STANDARD_WINDOW_MASK,
                   NS_BACKING_BUFFERED,
                   0 /* defer=NO */);
 

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -157,12 +157,9 @@ public final class CocoaWebView extends WebviewBase {
   // C function pointer (upcall stub) passed to dispatch_async_f to drain the pending queue
   private MemorySegment drainStub;
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
-  private final boolean borderless;
-
   public CocoaWebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
-    super(redirectConsole);
-    this.borderless = borderless;
+    super(redirectConsole, borderless);
     openWindows.incrementAndGet();
     buildDrainStub();
 

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
@@ -58,6 +58,19 @@ final class MacOSHelper {
     }
   }
 
+  /**
+   * Begins a native window-move operation for {@code nsWindow}, as if the user had grabbed the
+   * title bar, using the current NSEvent ({@code [NSApp currentEvent]}) as the originating mouse
+   * event that {@code performWindowDragWithEvent:} requires.
+   */
+  static void startWindowDrag(MemorySegment nsWindow) {
+    try (var a = Arena.ofConfined()) {
+      final var app = send0(ObjC.getClass(a, "NSApplication"), sel(a, "sharedApplication"));
+      final var event = send0(app, sel(a, "currentEvent"));
+      sendVoid1(nsWindow, sel(a, "performWindowDragWithEvent:"), event);
+    }
+  }
+
   static void setIcon(Path iconPath) {
     try (var a = Arena.ofConfined()) {
       final var app = send0(ObjC.getClass(a, "NSApplication"), sel(a, "sharedApplication"));

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -50,6 +50,7 @@ final class Win32 {
 
   // Window style / message constants
   static final int WS_OVERLAPPEDWINDOW = 0x00CF0000;
+  static final int WS_POPUP = 0x80000000;
   static final int WS_CHILD = 0x40000000;
   static final int WS_THICKFRAME = 0x00040000;
   static final int WS_MAXIMIZEBOX = 0x00010000;

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -53,6 +53,9 @@ final class Win32 {
   static final int WS_CHILD = 0x40000000;
   static final int WS_THICKFRAME = 0x00040000;
   static final int WS_MAXIMIZEBOX = 0x00010000;
+  static final int WS_CAPTION = 0x00C00000;
+  static final int WM_NCLBUTTONDOWN = 0x00A1;
+  static final int HTCAPTION = 2;
   static final int CW_USEDEFAULT = 0x80000000;
   static final int SW_HIDE = 0;
   static final int SW_SHOW = 5;
@@ -377,6 +380,17 @@ final class Win32 {
           FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_LONG, ADDRESS));
 
   /**
+   * {@code ReleaseCapture() -> BOOL}
+   *
+   * <p>Releases the current mouse capture. Required before sending {@link #WM_NCLBUTTONDOWN} with
+   * {@link #HTCAPTION} to start a native window-move loop from a synthetic (non-hardware) message -
+   * without this, the window ignores the fake non-client click while it still holds mouse capture
+   * from the original client-area click.
+   */
+  static final MethodHandle ReleaseCapture =
+      downcall(USER32, "ReleaseCapture", FunctionDescriptor.of(JAVA_INT));
+
+  /**
    * {@code GetModuleHandleW(lpModuleName) -> HMODULE}
    *
    * <p>Returns the module handle for the current process when passed {@code NULL}.
@@ -574,6 +588,24 @@ final class Win32 {
                   screenW,
                   screenH,
                   SWP_NOZORDER | SWP_FRAMECHANGED);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Begins a native window-move loop for {@code hwnd}, as if the user had clicked and dragged the
+   * title bar. Releases the current mouse capture first, then sends a synthetic {@link
+   * #WM_NCLBUTTONDOWN} with {@link #HTCAPTION}, which {@code DefWindowProc} handles by entering the
+   * standard move loop for as long as the mouse button stays down.
+   */
+  static void startWindowDrag(MemorySegment hwnd) {
+    try {
+      final var _ = (int) ReleaseCapture.invokeExact();
+      final var _ =
+          (long)
+              SendMessageW.invokeExact(
+                  hwnd, WM_NCLBUTTONDOWN, (long) HTCAPTION, MemorySegment.NULL);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -163,12 +163,9 @@ public final class Win32WebView extends WebviewBase {
   private MemorySegment mainWndProcStub, msgWndProcStub, widgetWndProcStub;
   private MemorySegment cachedQI, cachedAddRef, cachedRelease;
 
-  private final boolean borderless;
-
   public Win32WebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
-    super(redirectConsole);
-    this.borderless = borderless;
+    super(redirectConsole, borderless);
     Win32.coInitialize();
     Win32.enablePerMonitorDpiAwareness();
     buildWndProcStubs();

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -12,7 +12,6 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -164,8 +163,12 @@ public final class Win32WebView extends WebviewBase {
   private MemorySegment mainWndProcStub, msgWndProcStub, widgetWndProcStub;
   private MemorySegment cachedQI, cachedAddRef, cachedRelease;
 
-  public Win32WebView(boolean debug, boolean redirectConsole, int width, int height) {
+  private final boolean borderless;
+
+  public Win32WebView(
+      boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
     super(redirectConsole);
+    this.borderless = borderless;
     Win32.coInitialize();
     Win32.enablePerMonitorDpiAwareness();
     buildWndProcStubs();
@@ -342,6 +345,11 @@ public final class Win32WebView extends WebviewBase {
   public Webview fullscreen() {
     dispatchImpl(() -> Win32.fullscreen(hwnd));
     return this;
+  }
+
+  @Override
+  protected void startWindowDragImpl() {
+    Win32.startWindowDrag(hwnd);
   }
 
   @Override
@@ -548,13 +556,15 @@ public final class Win32WebView extends WebviewBase {
 
       final var mainCls = "AvajeWebView_" + System.identityHashCode(this);
       registerClass(a, hInstance, mainCls, mainWndProcStub);
+      final var style =
+          borderless ? Win32.WS_OVERLAPPEDWINDOW & ~Win32.WS_CAPTION : Win32.WS_OVERLAPPEDWINDOW;
       hwnd =
           (MemorySegment)
               Win32.CreateWindowExW.invokeExact(
                   0,
                   a.allocateFrom(mainCls, StandardCharsets.UTF_16LE),
                   a.allocateFrom("", StandardCharsets.UTF_16LE),
-                  Win32.WS_OVERLAPPEDWINDOW,
+                  style,
                   Win32.CW_USEDEFAULT,
                   Win32.CW_USEDEFAULT,
                   0,

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -556,8 +556,7 @@ public final class Win32WebView extends WebviewBase {
 
       final var mainCls = "AvajeWebView_" + System.identityHashCode(this);
       registerClass(a, hInstance, mainCls, mainWndProcStub);
-      final var style =
-          borderless ? Win32.WS_OVERLAPPEDWINDOW & ~Win32.WS_CAPTION : Win32.WS_OVERLAPPEDWINDOW;
+      final var style = borderless ? Win32.WS_POPUP : Win32.WS_OVERLAPPEDWINDOW;
       hwnd =
           (MemorySegment)
               Win32.CreateWindowExW.invokeExact(

--- a/examples/hello-world/src/main/java/BorderlessExample.java
+++ b/examples/hello-world/src/main/java/BorderlessExample.java
@@ -1,0 +1,95 @@
+import io.avaje.webview.Webview;
+
+String HTML =
+"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Borderless</title>
+  <style>
+  body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      border: 1px solid #444;
+      height: 100vh;
+      box-sizing: border-box;
+  }
+
+  .titlebar {
+      height: 36px;
+      background: #667eea;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 8px;
+      user-select: none;
+  }
+
+  .titlebar-close {
+      cursor: pointer;
+      padding: 4px 10px;
+  }
+
+  .titlebar-close:hover {
+      background: rgba(255, 255, 255, 0.2);
+  }
+
+  .content {
+      padding: 20px;
+  }
+  </style>
+</head>
+<body>
+  <div class="titlebar" id="titlebar">
+    <span>Borderless Window</span>
+    <span class="titlebar-close" onclick="closeWindow()">✕</span>
+  </div>
+  <div class="content">
+    <p>This window has no native title bar or border.</p>
+    <p>Drag the purple bar above to move the window.</p>
+  </div>
+
+  <script>
+    // Native decorations are gone (see .borderless(true) below), so dragging the
+    // colored bar has to start a native window-move ourselves via a bound function.
+    document.getElementById('titlebar').addEventListener('mousedown', event => {
+      if (event.button !== 0 || event.target.closest('.titlebar-close')) return;
+      startDrag();
+    });
+
+    function closeWindow() {
+      closeApp();
+    }
+  </script>
+</body>
+</html>
+""";
+
+void main() {
+  Webview webview =
+      Webview.builder()
+          .title("Borderless")
+          .width(500)
+          .height(300)
+          .borderless(true)
+          .html(HTML)
+          .build();
+
+  webview.bind(
+      "startDrag",
+      req -> {
+        webview.startWindowDrag();
+        return null;
+      });
+
+  webview.bind(
+      "closeApp",
+      req -> {
+        webview.close();
+        return null;
+      });
+
+  webview.run();
+}

--- a/examples/hello-world/src/main/java/BorderlessExample.java
+++ b/examples/hello-world/src/main/java/BorderlessExample.java
@@ -25,13 +25,11 @@ String HTML =
       justify-content: space-between;
       padding: 0 8px;
       user-select: none;
-      -webkit-app-region: drag;
   }
 
   .titlebar-close {
       cursor: pointer;
       padding: 4px 10px;
-      -webkit-app-region: no-drag;
   }
 
   .titlebar-close:hover {
@@ -44,14 +42,27 @@ String HTML =
   </style>
 </head>
 <body>
-  <div class="titlebar">
+  <div class="titlebar" id="titlebar">
     <span>Borderless Window</span>
-    <span class="titlebar-close" onclick="closeApp()">✕</span>
+    <span class="titlebar-close" onclick="closeWindow()">✕</span>
   </div>
   <div class="content">
     <p>This window has no native title bar or border.</p>
     <p>Drag the purple bar above to move the window.</p>
   </div>
+
+  <script>
+    // Native decorations are gone (see .borderless(true) below), so dragging the
+    // colored bar has to start a native window-move ourselves via a bound function.
+    document.getElementById('titlebar').addEventListener('mousedown', event => {
+      if (event.button !== 0 || event.target.closest('.titlebar-close')) return;
+      startDrag();
+    });
+
+    function closeWindow() {
+      closeApp();
+    }
+  </script>
 </body>
 </html>
 """;
@@ -65,6 +76,13 @@ void main() {
           .borderless(true)
           .html(HTML)
           .build();
+
+  webview.bind(
+      "startDrag",
+      req -> {
+        webview.startWindowDrag();
+        return null;
+      });
 
   webview.bind(
       "closeApp",

--- a/examples/hello-world/src/main/java/BorderlessExample.java
+++ b/examples/hello-world/src/main/java/BorderlessExample.java
@@ -25,11 +25,13 @@ String HTML =
       justify-content: space-between;
       padding: 0 8px;
       user-select: none;
+      -webkit-app-region: drag;
   }
 
   .titlebar-close {
       cursor: pointer;
       padding: 4px 10px;
+      -webkit-app-region: no-drag;
   }
 
   .titlebar-close:hover {
@@ -42,27 +44,14 @@ String HTML =
   </style>
 </head>
 <body>
-  <div class="titlebar" id="titlebar">
+  <div class="titlebar">
     <span>Borderless Window</span>
-    <span class="titlebar-close" onclick="closeWindow()">✕</span>
+    <span class="titlebar-close" onclick="closeApp()">✕</span>
   </div>
   <div class="content">
     <p>This window has no native title bar or border.</p>
     <p>Drag the purple bar above to move the window.</p>
   </div>
-
-  <script>
-    // Native decorations are gone (see .borderless(true) below), so dragging the
-    // colored bar has to start a native window-move ourselves via a bound function.
-    document.getElementById('titlebar').addEventListener('mousedown', event => {
-      if (event.button !== 0 || event.target.closest('.titlebar-close')) return;
-      startDrag();
-    });
-
-    function closeWindow() {
-      closeApp();
-    }
-  </script>
 </body>
 </html>
 """;
@@ -76,13 +65,6 @@ void main() {
           .borderless(true)
           .html(HTML)
           .build();
-
-  webview.bind(
-      "startDrag",
-      req -> {
-        webview.startWindowDrag();
-        return null;
-      });
 
   webview.bind(
       "closeApp",


### PR DESCRIPTION
- adds new method to make window borderless
- Add a method to enable a dragging event
- Support `-webkit-app-region` (on windows at least)  (It seems that it is an invalid css property on other platforms)

Resolves #103