### PR TITLE
Add Child Window Support + Minimize Function

### DIFF
--- a/avaje-webview/src/main/java/io/avaje/webview/Webview.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/Webview.java
@@ -312,6 +312,18 @@ public interface Webview extends Closeable, Runnable {
     Builder borderless(boolean borderless);
 
     /**
+     * Marks this window as owned by {@code parent}, making it behave like a modal child/dialog
+     * window.
+     *
+     * <p>The parent window is disabled (blocked from receiving mouse/keyboard input) as soon as
+     * this window is built, and automatically re-enabled when this window closes.
+     *
+     * @param parent the {@code Webview} that should be blocked while this window is open
+     * @return this builder
+     */
+    Builder parent(Webview parent);
+
+    /**
      * Builds a Webview using the configuration
      *
      * @return a configured Webview instance

--- a/avaje-webview/src/main/java/io/avaje/webview/Webview.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/Webview.java
@@ -203,6 +203,13 @@ public interface Webview extends Closeable, Runnable {
   Webview fullscreen();
 
   /**
+   * Minimizes the webview window to the taskbar/dock.
+   *
+   * @return this Webview instance for chaining
+   */
+  Webview minimizeWindow();
+
+  /**
    * Begins a native window-move operation, as if the user had grabbed the title bar and started
    * dragging.
    *
@@ -322,6 +329,23 @@ public interface Webview extends Closeable, Runnable {
      * @return this builder
      */
     Builder parent(Webview parent);
+
+    /**
+     * Maximizes the window immediately after it is shown. Defaults to {@code false}.
+     *
+     * @param maximize {@code true} to start maximized
+     * @return this builder
+     */
+    Builder maximize(boolean maximize);
+
+    /**
+     * Switches the window to fullscreen immediately after it is shown. Defaults to {@code false}.
+     * Takes precedence over {@link #maximize(boolean)} when both are set.
+     *
+     * @param fullscreen {@code true} to start fullscreen
+     * @return this builder
+     */
+    Builder fullscreen(boolean fullscreen);
 
     /**
      * Builds a Webview using the configuration

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -72,10 +72,12 @@ public abstract sealed class WebviewBase implements Webview
 
   private final boolean redirectConsole;
   protected final boolean borderless;
+  protected final MemorySegment parentWindow;
 
-  protected WebviewBase(boolean redirectConsole, boolean borderless) {
+  protected WebviewBase(boolean redirectConsole, boolean borderless, MemorySegment parentWindow) {
     this.redirectConsole = redirectConsole;
     this.borderless = borderless;
+    this.parentWindow = parentWindow != null ? parentWindow : MemorySegment.NULL;
   }
 
   // JS bridge state, all mutations to userScripts/bindScriptIdx must happen on the main thread
@@ -103,7 +105,7 @@ public abstract sealed class WebviewBase implements Webview
   private void setupAppRegionDrag() {
     bind(
         "__avaje_wv_drag__",
-        req -> {
+        _ -> {
           startWindowDragImpl();
           return "null";
         });

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -234,6 +234,9 @@ public abstract sealed class WebviewBase implements Webview
   public abstract Webview fullscreen();
 
   @Override
+  public abstract Webview minimizeWindow();
+
+  @Override
   public void startWindowDrag() {
     dispatchImpl(this::startWindowDragImpl);
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -17,6 +17,7 @@ final class WebviewBuilder implements Builder {
   private String html;
   private String url;
   private boolean borderless;
+  private Webview parent;
 
   WebviewBuilder() {}
 
@@ -74,6 +75,12 @@ final class WebviewBuilder implements Builder {
   }
 
   @Override
+  public WebviewBuilder parent(Webview parent) {
+    this.parent = parent;
+    return this;
+  }
+
+  @Override
   public Webview build() {
     final var view = createForPlatform();
     if (title != null) view.setTitle(title);
@@ -89,12 +96,16 @@ final class WebviewBuilder implements Builder {
 
   private Webview createForPlatform() {
     final var os = System.getProperty("os.name", "").toLowerCase();
+    final var parentPtr = parent != null ? parent.nativeWindowPointer() : MemorySegment.NULL;
     if (os.contains("win"))
-      return new Win32WebView(enableDeveloperTools, redirectConsole, width, height, borderless);
+      return new Win32WebView(
+          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
     if (os.contains("mac"))
-      return new CocoaWebView(enableDeveloperTools, redirectConsole, width, height, borderless);
+      return new CocoaWebView(
+          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
     if (os.contains("linux"))
-      return new GtkWebView(enableDeveloperTools, redirectConsole, width, height, borderless);
+      return new GtkWebView(
+          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
     throw new UnsupportedOperationException(
         "Unsupported platform: " + System.getProperty("os.name"));
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -18,6 +18,8 @@ final class WebviewBuilder implements Builder {
   private String url;
   private boolean borderless;
   private MemorySegment parent = MemorySegment.NULL;
+  private boolean maximize;
+  private boolean fullscreen;
 
   WebviewBuilder() {}
 
@@ -81,6 +83,18 @@ final class WebviewBuilder implements Builder {
   }
 
   @Override
+  public WebviewBuilder maximize(boolean maximize) {
+    this.maximize = maximize;
+    return this;
+  }
+
+  @Override
+  public WebviewBuilder fullscreen(boolean fullscreen) {
+    this.fullscreen = fullscreen;
+    return this;
+  }
+
+  @Override
   public Webview build() {
     final var view = createForPlatform();
     if (title != null) view.setTitle(title);
@@ -90,6 +104,11 @@ final class WebviewBuilder implements Builder {
       view.setHTML(html);
     } else {
       view.navigate("about:blank");
+    }
+    if (fullscreen) {
+      view.fullscreen();
+    } else if (maximize) {
+      view.maximizeWindow();
     }
     return view;
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -17,7 +17,7 @@ final class WebviewBuilder implements Builder {
   private String html;
   private String url;
   private boolean borderless;
-  private Webview parent;
+  private MemorySegment parent = MemorySegment.NULL;
 
   WebviewBuilder() {}
 
@@ -76,7 +76,7 @@ final class WebviewBuilder implements Builder {
 
   @Override
   public WebviewBuilder parent(Webview parent) {
-    this.parent = parent;
+    this.parent = parent.nativeWindowPointer();
     return this;
   }
 
@@ -96,16 +96,15 @@ final class WebviewBuilder implements Builder {
 
   private Webview createForPlatform() {
     final var os = System.getProperty("os.name", "").toLowerCase();
-    final var parentPtr = parent != null ? parent.nativeWindowPointer() : MemorySegment.NULL;
     if (os.contains("win"))
       return new Win32WebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
+          enableDeveloperTools, redirectConsole, width, height, borderless, parent);
     if (os.contains("mac"))
       return new CocoaWebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
+          enableDeveloperTools, redirectConsole, width, height, borderless, parent);
     if (os.contains("linux"))
       return new GtkWebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, parentPtr);
+          enableDeveloperTools, redirectConsole, width, height, borderless, parent);
     throw new UnsupportedOperationException(
         "Unsupported platform: " + System.getProperty("os.name"));
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
@@ -133,10 +133,17 @@ final class Gtk4 {
       downcall("gtk_window_destroy", FunctionDescriptor.ofVoid(ADDRESS));
 
   /**
+   * {@code gtk_window_minimize(GtkWindow* window) -> void}
+   *
+   * <p>Asks the window manager to minimize the window to the taskbar.
+   */
+  private static final MethodHandle GTK_WINDOW_MINIMIZE =
+      downcall("gtk_window_minimize", FunctionDescriptor.ofVoid(ADDRESS));
+
+  /**
    * {@code gtk_window_maximize(GtkWindow* window) -> void}
    *
-   * <p>Asks the window manager to maximize the window. The request is asynchronous; the actual
-   * resize happens on the next event loop iteration when the compositor responds.
+   * <p>Asks the window manager to maximize the window.
    */
   private static final MethodHandle GTK_WINDOW_MAXIMIZE =
       downcall("gtk_window_maximize", FunctionDescriptor.ofVoid(ADDRESS));
@@ -144,8 +151,7 @@ final class Gtk4 {
   /**
    * {@code gtk_window_fullscreen(GtkWindow* window) -> void}
    *
-   * <p>Asks the window manager to switch the window to fullscreen mode. Like {@link
-   * #GTK_WINDOW_MAXIMIZE}, the transition is compositor-driven and asynchronous.
+   * <p>Asks the window manager to switch the window to fullscreen mode.
    */
   private static final MethodHandle GTK_WINDOW_FULLSCREEN =
       downcall("gtk_window_fullscreen", FunctionDescriptor.ofVoid(ADDRESS));
@@ -413,6 +419,19 @@ final class Gtk4 {
   static void gtkWindowDestroy(MemorySegment window) {
     try {
       GTK_WINDOW_DESTROY.invokeExact(window);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Asks the window manager to minimize (iconify) the window to the taskbar.
+   *
+   * @param window a {@code GtkWindow*}
+   */
+  static void gtkWindowMinimize(MemorySegment window) {
+    try {
+      GTK_WINDOW_MINIMIZE.invokeExact(window);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
@@ -96,17 +96,38 @@ final class Gtk4 {
       downcall("gtk_window_set_child", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
 
   /**
+   * {@code gtk_window_set_transient_for(GtkWindow* window, GtkWindow* parent) -> void}
+   *
+   * <p>Marks {@code window} as logically attached to {@code parent}: the window manager keeps it
+   * stacked above the parent and typically minimizes/restores it together with the parent.
+   */
+  private static final MethodHandle GTK_WINDOW_SET_TRANSIENT_FOR =
+      downcall("gtk_window_set_transient_for", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+
+  /**
+   * {@code gtk_window_set_modal(GtkWindow* window, gboolean modal) -> void}
+   *
+   * <p>Combined with {@link #GTK_WINDOW_SET_TRANSIENT_FOR}, tells the window manager this is a
+   * modal dialog relative to its transient parent.
+   */
+  private static final MethodHandle GTK_WINDOW_SET_MODAL =
+      downcall("gtk_window_set_modal", FunctionDescriptor.ofVoid(ADDRESS, JAVA_INT));
+
+  /**
+   * {@code gtk_widget_set_sensitive(GtkWidget* widget, gboolean sensitive) -> void}
+   *
+   * <p>Enables or disables input to every widget in the tree rooted at {@code widget}.
+   */
+  private static final MethodHandle GTK_WIDGET_SET_SENSITIVE =
+      downcall("gtk_widget_set_sensitive", FunctionDescriptor.ofVoid(ADDRESS, JAVA_INT));
+
+  /**
    * {@code gtk_window_destroy(GtkWindow* window) -> void}
    *
    * <p>Destroys the window unconditionally, bypassing the {@code "close-request"} veto mechanism.
    * GTK emits the {@code "destroy"} signal synchronously during this call, so our {@code
    * GtkWebView#onWindowDestroy} upcall runs and decrements {@code openWindows} before {@code
    * gtkWindowDestroy} returns.
-   *
-   * <p>Added in GTK 4.0; replaces the old pattern of calling {@code gtk_widget_destroy()} on the
-   * window. Prefer this over {@code gtk_window_close} for programmatic shutdown because it
-   * guarantees teardown even if third-party code has connected a vetoing {@code close-request}
-   * handler.
    */
   private static final MethodHandle GTK_WINDOW_DESTROY =
       downcall("gtk_window_destroy", FunctionDescriptor.ofVoid(ADDRESS));
@@ -333,6 +354,49 @@ final class Gtk4 {
   static void gtkWindowSetChild(MemorySegment window, MemorySegment child) {
     try {
       GTK_WINDOW_SET_CHILD.invokeExact(window, child);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Marks {@code window} as transient for {@code parent} so the window manager keeps it attached
+   * (stacked above, minimized/restored together).
+   *
+   * @param window a {@code GtkWindow*}
+   * @param parent a {@code GtkWindow*}
+   */
+  static void gtkWindowSetTransientFor(MemorySegment window, MemorySegment parent) {
+    try {
+      GTK_WINDOW_SET_TRANSIENT_FOR.invokeExact(window, parent);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Marks {@code window} as a modal dialog relative to its transient parent.
+   *
+   * @param window a {@code GtkWindow*}
+   * @param modal {@code true} to mark modal
+   */
+  static void gtkWindowSetModal(MemorySegment window, boolean modal) {
+    try {
+      GTK_WINDOW_SET_MODAL.invokeExact(window, modal ? 1 : 0);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Enables or disables input to {@code widget} and its descendants.
+   *
+   * @param widget a {@code GtkWidget*}
+   * @param sensitive {@code false} blocks input (clicks are ignored) until re-enabled
+   */
+  static void gtkWidgetSetSensitive(MemorySegment widget, boolean sensitive) {
+    try {
+      GTK_WIDGET_SET_SENSITIVE.invokeExact(widget, sensitive ? 1 : 0);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -312,6 +312,12 @@ public final class GtkWebView extends WebviewBase {
   }
 
   @Override
+  public Webview minimizeWindow() {
+    dispatchImpl(() -> LinuxHelper.minimizeWindow(this));
+    return this;
+  }
+
+  @Override
   protected void startWindowDragImpl() {
     LinuxHelper.startWindowDrag(this);
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -51,9 +51,6 @@ public final class GtkWebView extends WebviewBase {
   private volatile MemorySegment webView; // WebKitWebView*
   private volatile MemorySegment ucManager; // WebKitUserContentManager*
 
-  /** Parent window handle */
-  private final MemorySegment parentWindow;
-
   private boolean windowShown = false;
   private volatile boolean closed = false;
   private volatile boolean windowDestroyed = false;
@@ -90,10 +87,9 @@ public final class GtkWebView extends WebviewBase {
       int height,
       boolean borderless,
       MemorySegment parentWindow) {
-    super(redirectConsole, borderless);
+    super(redirectConsole, borderless, parentWindow);
     this.initialWidth = width;
     this.initialHeight = height;
-    this.parentWindow = parentWindow == null ? MemorySegment.NULL : parentWindow;
     openWindows.incrementAndGet();
 
     if (gtkThread == null || gtkThread == Thread.currentThread()) {

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -8,7 +8,6 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -52,6 +51,9 @@ public final class GtkWebView extends WebviewBase {
   private volatile MemorySegment webView; // WebKitWebView*
   private volatile MemorySegment ucManager; // WebKitUserContentManager*
 
+  /** Parent window handle */
+  private final MemorySegment parentWindow;
+
   private boolean windowShown = false;
   private volatile boolean closed = false;
   private volatile boolean windowDestroyed = false;
@@ -75,11 +77,23 @@ public final class GtkWebView extends WebviewBase {
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
   private final int initialWidth;
   private final int initialHeight;
+
   public GtkWebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
+    this(debug, redirectConsole, width, height, borderless, MemorySegment.NULL);
+  }
+
+  public GtkWebView(
+      boolean debug,
+      boolean redirectConsole,
+      int width,
+      int height,
+      boolean borderless,
+      MemorySegment parentWindow) {
     super(redirectConsole, borderless);
     this.initialWidth = width;
     this.initialHeight = height;
+    this.parentWindow = parentWindow == null ? MemorySegment.NULL : parentWindow;
     openWindows.incrementAndGet();
 
     if (gtkThread == null || gtkThread == Thread.currentThread()) {
@@ -169,6 +183,9 @@ public final class GtkWebView extends WebviewBase {
     // We cannot close it here: this method runs inside drainDispatchQueue (an upcall stub in the
     // arena), so closing now would free memory the stub is still executing from.
     pendingArenaClose.add(callbackArena);
+    if (parentWindow.address() != 0L) {
+      Gtk4.gtkWidgetSetSensitive(parentWindow, true);
+    }
   }
 
   @Override
@@ -454,6 +471,11 @@ public final class GtkWebView extends WebviewBase {
     window = Gtk4.gtkWindowNew();
     if (borderless) Gtk4.gtkWindowSetDecorated(window, false);
     GLib.gSignalConnect(window, "destroy", destroyStub, MemorySegment.NULL);
+    if (parentWindow.address() != 0L) {
+      Gtk4.gtkWindowSetTransientFor(window, parentWindow);
+      Gtk4.gtkWindowSetModal(window, true);
+      Gtk4.gtkWidgetSetSensitive(parentWindow, false);
+    }
 
     webView = WebKit6.webkitWebViewNew();
     // webkit_web_view_new() returns a GObject with a floating reference (refcount=1, floating flag

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
@@ -15,6 +15,11 @@ final class LinuxHelper {
     Gtk4.gtkWindowFullscreen(webview.nativeWindowPointer());
   }
 
+  /** Asks the window manager to minimize (iconify) the window. */
+  static void minimizeWindow(Webview webview) {
+    Gtk4.gtkWindowMinimize(webview.nativeWindowPointer());
+  }
+
   /** Requests the window manager to maximize the window. */
   static void maximizeWindow(Webview webview) {
     Gtk4.gtkWindowMaximize(webview.nativeWindowPointer());

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -708,7 +708,7 @@ public final class CocoaWebView extends WebviewBase {
                   0d,
                   (double) width,
                   (double) height,
-                  borderless ? NS_RESIZABLE : NS_STANDARD_WINDOW_MASK,
+                  borderless ? NS_RESIZABLE | NS_MINIATURIZABLE : NS_STANDARD_WINDOW_MASK,
                   NS_BACKING_BUFFERED,
                   0 /* defer=NO */);
 

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -172,9 +172,6 @@ public final class CocoaWebView extends WebviewBase {
   private volatile MemorySegment wkWebView; // WKWebView*
   private volatile MemorySegment ucController; // WKUserContentController*
 
-  /** Parent window handle (NSWindow*) */
-  private final MemorySegment parentWindow;
-
   /** Intercepts clicks intended for the parent and redirects them into a flash of this window */
   private volatile MemorySegment parentClickGuard = MemorySegment.NULL;
 
@@ -203,8 +200,7 @@ public final class CocoaWebView extends WebviewBase {
       int height,
       boolean borderless,
       MemorySegment parentWindow) {
-    super(redirectConsole, borderless);
-    this.parentWindow = parentWindow == null ? MemorySegment.NULL : parentWindow;
+    super(redirectConsole, borderless, parentWindow);
     openWindows.incrementAndGet();
     buildDrainStub();
 
@@ -710,9 +706,11 @@ public final class CocoaWebView extends WebviewBase {
                   NS_BACKING_BUFFERED,
                   0 /* defer=NO */);
 
-      // initWithContentRect: ignores the origin we pass (0,0) and leaves the window at the
-      // bottom-left of the main screen; center() places it where users actually expect it.
-      MacOSHelper.center(nsWindow);
+      if (parentWindow.address() != 0) {
+        MacOSHelper.centerOnParent(nsWindow, parentWindow);
+      } else {
+        MacOSHelper.center(nsWindow);
+      }
 
       sendVoid1(nsWindow, sel(a, "setDelegate:"), createWindowDelegate(a));
       sendVoid1(nsWindow, sel(a, "setContentView:"), wkWebView);
@@ -856,7 +854,7 @@ public final class CocoaWebView extends WebviewBase {
       final var _ =
           (byte)
               CLASS_ADD_METHOD.invokeExact(cls, sel(a, "mouseDown:"), stub, a.allocateFrom("v@:@"));
-      final var _2 =
+      final var _ =
           (byte)
               CLASS_ADD_METHOD.invokeExact(
                   cls, sel(a, "rightMouseDown:"), stub, a.allocateFrom("v@:@"));

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -459,6 +459,12 @@ public final class CocoaWebView extends WebviewBase {
   }
 
   @Override
+  public Webview minimizeWindow() {
+    dispatchImpl(() -> MacOSHelper.minimize(nsWindow));
+    return this;
+  }
+
+  @Override
   protected void startWindowDragImpl() {
     MacOSHelper.startWindowDrag(nsWindow);
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -109,6 +109,20 @@ public final class CocoaWebView extends WebviewBase {
    */
   private static final MethodHandle DISPATCH_ASYNC_F;
 
+  /**
+   * {@code dispatch_time(dispatch_time_t when, int64_t delta) -> dispatch_time_t}. {@code
+   * DISPATCH_TIME_NOW} is {@code 0}; {@code delta} is nanoseconds from that base. Used to compute
+   * the deadline for {@link #DISPATCH_AFTER_F}.
+   */
+  private static final MethodHandle DISPATCH_TIME;
+
+  /**
+   * {@code dispatch_after_f(dispatch_time_t when, dispatch_queue_t queue, void* context,
+   * dispatch_function_t work)}. Same {@code void(*)(void*)} C-function-pointer shape as {@link
+   * #DISPATCH_ASYNC_F}, just deferred to a deadline .
+   */
+  private static final MethodHandle DISPATCH_AFTER_F;
+
   // NSApplication is a process singleton; only init once across all CocoaWebView instances.
   private static volatile boolean nsAppInitDone = false;
   private static final AtomicInteger openWindows = new AtomicInteger(0);
@@ -139,11 +153,30 @@ public final class CocoaWebView extends WebviewBase {
             lookup.find("dispatch_async_f").orElseThrow(),
             FunctionDescriptor.ofVoid(
                 ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    DISPATCH_TIME =
+        linker.downcallHandle(
+            lookup.find("dispatch_time").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG));
+    DISPATCH_AFTER_F =
+        linker.downcallHandle(
+            lookup.find("dispatch_after_f").orElseThrow(),
+            FunctionDescriptor.ofVoid(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.ADDRESS,
+                ValueLayout.ADDRESS));
   }
 
   private volatile MemorySegment nsWindow; // NSWindow*
   private volatile MemorySegment wkWebView; // WKWebView*
   private volatile MemorySegment ucController; // WKUserContentController*
+
+  /** Parent window handle (NSWindow*) */
+  private final MemorySegment parentWindow;
+
+  /** Intercepts clicks intended for the parent and redirects them into a flash of this window */
+  private volatile MemorySegment parentClickGuard = MemorySegment.NULL;
 
   private volatile boolean closed = false;
   private final AtomicBoolean windowClosed = new AtomicBoolean(false);
@@ -157,9 +190,21 @@ public final class CocoaWebView extends WebviewBase {
   // C function pointer (upcall stub) passed to dispatch_async_f to drain the pending queue
   private MemorySegment drainStub;
   private final ConcurrentLinkedQueue<Runnable> pendingDispatches = new ConcurrentLinkedQueue<>();
+
   public CocoaWebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
+    this(debug, redirectConsole, width, height, borderless, MemorySegment.NULL);
+  }
+
+  public CocoaWebView(
+      boolean debug,
+      boolean redirectConsole,
+      int width,
+      int height,
+      boolean borderless,
+      MemorySegment parentWindow) {
     super(redirectConsole, borderless);
+    this.parentWindow = parentWindow == null ? MemorySegment.NULL : parentWindow;
     openWindows.incrementAndGet();
     buildDrainStub();
 
@@ -349,6 +394,30 @@ public final class CocoaWebView extends WebviewBase {
     }
   }
 
+  /**
+   * Runs {@code r} on the main thread after {@code delayMillis}. Unlike {@link #dispatchImpl},
+   * which drains a shared FIFO queue immediately, this builds a one-off upcall stub per call so the
+   * delay is honored precisely.
+   */
+  private void dispatchAfterImpl(long delayMillis, Runnable r) {
+    try {
+      final var when = (long) DISPATCH_TIME.invokeExact(0L, delayMillis * 1_000_000L);
+      final var runIt =
+          MethodHandles.lookup()
+              .findVirtual(Runnable.class, "run", MethodType.methodType(void.class))
+              .bindTo(r);
+      final var stub =
+          Linker.nativeLinker()
+              .upcallStub(
+                  MethodHandles.dropArguments(runIt, 0, MemorySegment.class),
+                  FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+                  callbackArena);
+      DISPATCH_AFTER_F.invokeExact(when, DISPATCH_MAIN_QUEUE, MemorySegment.NULL, stub);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
   @Override
   protected void nativeAddUserScript(String js) {
     if (closed) return;
@@ -453,6 +522,13 @@ public final class CocoaWebView extends WebviewBase {
   public void onWindowWillClose(MemorySegment self, MemorySegment cmd, MemorySegment notification) {
     if (!windowClosed.compareAndSet(false, true)) return;
     closed = true;
+    if (parentWindow.address() != 0) {
+      MacOSHelper.removeChildWindow(parentWindow, nsWindow);
+      MacOSHelper.removeClickGuard(parentClickGuard);
+      try (var a = Arena.ofConfined()) {
+        sendVoid1(parentWindow, sel(a, "makeKeyAndOrderFront:"), MemorySegment.NULL);
+      }
+    }
     if (openWindows.decrementAndGet() == 0) {
       try (var a = Arena.ofConfined()) {
         final var app = send0(ObjC.getClass(a, "NSApplication"), sel(a, "sharedApplication"));
@@ -460,6 +536,26 @@ public final class CocoaWebView extends WebviewBase {
       }
     }
     windowClosedLatch.countDown();
+  }
+
+  /**
+   * Called by the click-guard overlay view (see {@link #createClickGuardView}) when the user clicks
+   * anywhere on {@link #parentWindow} while this window owns it. Does not forward the click - the
+   * guard view swallows it by never calling {@code super} - and instead flashes this window so the
+   * user notices it needs attention.
+   */
+  @SuppressWarnings("unused")
+  public void onParentClickBlocked(MemorySegment self, MemorySegment cmd, MemorySegment event) {
+    flashChildWindow();
+  }
+
+  /** Brings this window to the front and briefly dips/restores its opacity as a "flash" cue. */
+  private void flashChildWindow() {
+    try (var a = Arena.ofConfined()) {
+      sendVoid1(nsWindow, sel(a, "makeKeyAndOrderFront:"), MemorySegment.NULL);
+    }
+    MacOSHelper.setAlphaValue(nsWindow, 0.35d);
+    dispatchAfterImpl(140L, () -> MacOSHelper.setAlphaValue(nsWindow, 1.0d));
   }
 
   /**
@@ -614,10 +710,21 @@ public final class CocoaWebView extends WebviewBase {
                   NS_BACKING_BUFFERED,
                   0 /* defer=NO */);
 
+      // initWithContentRect: ignores the origin we pass (0,0) and leaves the window at the
+      // bottom-left of the main screen; center() places it where users actually expect it.
+      MacOSHelper.center(nsWindow);
+
       sendVoid1(nsWindow, sel(a, "setDelegate:"), createWindowDelegate(a));
       sendVoid1(nsWindow, sel(a, "setContentView:"), wkWebView);
       // Navigation delegate shows the window once the first page finishes loading.
       sendVoid1(wkWebView, sel(a, "setNavigationDelegate:"), createNavigationDelegate(a));
+
+      if (parentWindow.address() != 0) {
+        MacOSHelper.addChildWindow(parentWindow, nsWindow);
+        parentClickGuard = createClickGuardView(a);
+        MacOSHelper.installFillAutoresizeMask(parentClickGuard);
+        MacOSHelper.attachClickGuard(parentWindow, parentClickGuard);
+      }
 
       setupJsBridge(POST_FN);
       // Window is shown from onNavigationFinished when the first page load completes.
@@ -710,6 +817,55 @@ public final class CocoaWebView extends WebviewBase {
 
       REGISTER_CLASS_PAIR.invokeExact(cls);
       return (MemorySegment) CLASS_CREATE_INSTANCE.invokeExact(cls, 0L);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Synthesizes an {@code NSView} subclass whose {@code mouseDown:}/{@code rightMouseDown:} both
+   * call back into {@link #onParentClickBlocked} and never invoke {@code super} - so the click
+   * never reaches whatever real content is underneath. An instance of this class is installed as an
+   * overlay over {@link #parentWindow}'s content view for as long as this window is open.
+   */
+  private MemorySegment createClickGuardView(Arena a) {
+    try {
+      final var superCls = ObjC.getClass(a, "NSView");
+      final var clsName = "JavaWebviewClickGuard_" + System.identityHashCode(this);
+      final var cls =
+          (MemorySegment) ALLOC_CLASS_PAIR.invokeExact(superCls, a.allocateFrom(clsName), 0L);
+
+      final var mh =
+          MethodHandles.lookup()
+              .findVirtual(
+                  CocoaWebView.class,
+                  "onParentClickBlocked",
+                  MethodType.methodType(
+                      void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class))
+              .bindTo(this);
+      final var stub =
+          Linker.nativeLinker()
+              .upcallStub(
+                  mh,
+                  FunctionDescriptor.ofVoid(
+                      ValueLayout.ADDRESS, // self
+                      ValueLayout.ADDRESS, // cmd
+                      ValueLayout.ADDRESS), // NSEvent*
+                  callbackArena);
+
+      final var _ =
+          (byte)
+              CLASS_ADD_METHOD.invokeExact(cls, sel(a, "mouseDown:"), stub, a.allocateFrom("v@:@"));
+      final var _2 =
+          (byte)
+              CLASS_ADD_METHOD.invokeExact(
+                  cls, sel(a, "rightMouseDown:"), stub, a.allocateFrom("v@:@"));
+
+      REGISTER_CLASS_PAIR.invokeExact(cls);
+      final var raw = (MemorySegment) CLASS_CREATE_INSTANCE.invokeExact(cls, 0L);
+      return (MemorySegment)
+          ObjC.MSG_SEND_INIT_WITH_FRAME.invokeExact(
+              raw, sel(a, "initWithFrame:"), 0d, 0d, 100_000d, 100_000d);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
@@ -60,6 +60,12 @@ final class MacOSHelper {
     }
   }
 
+  static void minimize(MemorySegment nsWindow) {
+    try (var a = Arena.ofConfined()) {
+      sendVoid1(nsWindow, sel(a, "miniaturize:"), MemorySegment.NULL);
+    }
+  }
+
   /**
    * Begins a native window-move operation for {@code nsWindow}, as if the user had grabbed the
    * title bar, using the current NSEvent ({@code [NSApp currentEvent]}) as the originating mouse

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
@@ -71,6 +71,101 @@ final class MacOSHelper {
     }
   }
 
+  /**
+   * {@code -[NSWindow addChildWindow:ordered:]} - attaches {@code childWindow} to {@code
+   * parentWindow} so the window manager keeps it stacked above the parent and moves it together.
+   * {@code ordered = NSWindowAbove (1)}.
+   */
+  static void addChildWindow(MemorySegment parentWindow, MemorySegment childWindow) {
+    try (var a = Arena.ofConfined()) {
+      Linker.nativeLinker()
+          .downcallHandle(
+              ObjC.MSG_SEND_ADDR,
+              FunctionDescriptor.ofVoid(
+                  ValueLayout.ADDRESS,
+                  ValueLayout.ADDRESS,
+                  ValueLayout.ADDRESS,
+                  ValueLayout.JAVA_LONG))
+          .invokeExact(
+              parentWindow, sel(a, "addChildWindow:ordered:"), childWindow, 1L /* NSWindowAbove */);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * {@code -[NSWindow removeChildWindow:]} - detaches a window added via {@link #addChildWindow}.
+   */
+  static void removeChildWindow(MemorySegment parentWindow, MemorySegment childWindow) {
+    try (var a = Arena.ofConfined()) {
+      sendVoid1(parentWindow, sel(a, "removeChildWindow:"), childWindow);
+    }
+  }
+
+  /**
+   * {@code -[NSWindow setAlphaValue:]} - sets window opacity (0.0-1.0). Used to briefly dip and
+   * restore a child window's opacity to "flash" it when the user clicks its disabled parent.
+   */
+  static void setAlphaValue(MemorySegment window, double alpha) {
+    try (var a = Arena.ofConfined()) {
+      Linker.nativeLinker()
+          .downcallHandle(
+              ObjC.MSG_SEND_ADDR,
+              FunctionDescriptor.ofVoid(
+                  ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_DOUBLE))
+          .invokeExact(window, sel(a, "setAlphaValue:"), alpha);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * {@code -[NSWindow center]} - centers {@code window} on the screen it mostly occupies. Without
+   * this, {@code initWithContentRect:} leaves the window at its raw origin, which is the
+   * bottom-left corner of the main screen in Cocoa's coordinate system.
+   */
+  static void center(MemorySegment window) {
+    try (var a = Arena.ofConfined()) {
+      sendVoid0(window, sel(a, "center"));
+    }
+  }
+
+  /**
+   * Installs a fill autoresizing mask on {@code view} (already created with an oversized frame -
+   * see {@link ObjC#MSG_SEND_INIT_WITH_FRAME}) so it keeps covering the parent as it resizes.
+   * {@code NSViewWidthSizable (1<<1) | NSViewHeightSizable (1<<4) = 18}.
+   */
+  static void installFillAutoresizeMask(MemorySegment view) {
+    try (var a = Arena.ofConfined()) {
+      Linker.nativeLinker()
+          .downcallHandle(
+              ObjC.MSG_SEND_ADDR,
+              FunctionDescriptor.ofVoid(
+                  ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG))
+          .invokeExact(view, sel(a, "setAutoresizingMask:"), 18L);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Adds {@code guardView} as the frontmost subview of {@code window}'s content view, so it
+   * intercepts every click before the real content underneath sees it.
+   */
+  static void attachClickGuard(MemorySegment window, MemorySegment guardView) {
+    try (var a = Arena.ofConfined()) {
+      final var contentView = send0(window, sel(a, "contentView"));
+      sendVoid1(contentView, sel(a, "addSubview:"), guardView);
+    }
+  }
+
+  /** Detaches a guard view added via {@link #attachClickGuard}. */
+  static void removeClickGuard(MemorySegment guardView) {
+    try (var a = Arena.ofConfined()) {
+      sendVoid0(guardView, sel(a, "removeFromSuperview"));
+    }
+  }
+
   static void setIcon(Path iconPath) {
     try (var a = Arena.ofConfined()) {
       final var app = send0(ObjC.getClass(a, "NSApplication"), sel(a, "sharedApplication"));

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
@@ -1,5 +1,7 @@
 package io.avaje.webview.macos;
 
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+
 import static io.avaje.webview.macos.ObjC.fromNSString;
 import static io.avaje.webview.macos.ObjC.nsString;
 import static io.avaje.webview.macos.ObjC.sel;
@@ -127,6 +129,28 @@ final class MacOSHelper {
   static void center(MemorySegment window) {
     try (var a = Arena.ofConfined()) {
       sendVoid0(window, sel(a, "center"));
+    }
+  }
+
+  /**
+   * Centers {@code nsWindow} relative to {@code parentWindow} by reading both frames and computing
+   * the origin that places the child at the center of the parent.
+   */
+  static void centerOnParent(MemorySegment nsWindow, MemorySegment parentWindow) {
+    try (var a = Arena.ofConfined()) {
+      final var frameSel = sel(a, "frame");
+      final var pFrame = (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact(parentWindow, frameSel);
+      final var cFrame = (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact(nsWindow, frameSel);
+      final double pX = pFrame.get(JAVA_DOUBLE, 0);
+      final double pY = pFrame.get(JAVA_DOUBLE, 8);
+      final double pW = pFrame.get(JAVA_DOUBLE, 16);
+      final double pH = pFrame.get(JAVA_DOUBLE, 24);
+      final double cW = cFrame.get(JAVA_DOUBLE, 16);
+      final double cH = cFrame.get(JAVA_DOUBLE, 24);
+      ObjC.MSG_SEND_SET_SIZE.invokeExact(
+          nsWindow, sel(a, "setFrameOrigin:"), pX + (pW - cW) / 2, pY + (pH - cH) / 2);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
     }
   }
 

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/ObjC.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/ObjC.java
@@ -9,7 +9,9 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 
@@ -258,6 +260,22 @@ final class ObjC {
   static final MethodHandle MSG_SEND_SET_CONTENT_SIZE =
       LINKER.downcallHandle(
           MSG_SEND_ADDR, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_DOUBLE, JAVA_DOUBLE));
+
+  /** {@code NSRect} layout: x, y, width, height. */
+  static final StructLayout NS_RECT_LAYOUT =
+      MemoryLayout.structLayout(
+          JAVA_DOUBLE.withName("x"),
+          JAVA_DOUBLE.withName("y"),
+          JAVA_DOUBLE.withName("w"),
+          JAVA_DOUBLE.withName("h"));
+
+  /**
+   * {@code -[NSWindow frame] -> NSRect}
+   *
+   * <p>Returns the window's frame rectangle in screen coordinates.
+   */
+  static final MethodHandle MSG_SEND_GET_FRAME =
+      LINKER.downcallHandle(MSG_SEND_ADDR, FunctionDescriptor.of(NS_RECT_LAYOUT, ADDRESS, ADDRESS));
 
   /**
    * {@code -[NSView initWithFrame:] -> id}

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/ObjC.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/ObjC.java
@@ -259,6 +259,18 @@ final class ObjC {
       LINKER.downcallHandle(
           MSG_SEND_ADDR, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_DOUBLE, JAVA_DOUBLE));
 
+  /**
+   * {@code -[NSView initWithFrame:] -> id}
+   *
+   * <p>Same {@code NSRect}-as-four-inline-doubles ABI as {@link #MSG_SEND_NSWINDOW_INIT}.This must
+   * be called on every freshly allocated {@code NSView} before use.
+   */
+  static final MethodHandle MSG_SEND_INIT_WITH_FRAME =
+      LINKER.downcallHandle(
+          MSG_SEND_ADDR,
+          FunctionDescriptor.of(
+              ADDRESS, ADDRESS, ADDRESS, JAVA_DOUBLE, JAVA_DOUBLE, JAVA_DOUBLE, JAVA_DOUBLE));
+
   private static MethodHandle downcall(SymbolLookup lib, String sym, FunctionDescriptor desc) {
     return LINKER.downcallHandle(
         lib.find(sym).orElseThrow(() -> new UnsatisfiedLinkError("ObjC symbol not found: " + sym)),

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -253,6 +253,22 @@ final class Win32 {
       downcall(USER32, "SetFocus", FunctionDescriptor.of(ADDRESS, ADDRESS));
 
   /**
+   * {@code EnableWindow(hWnd, bEnable) -> BOOL}
+   *
+   * <p>Enables or disables mouse/keyboard input to a window. Used to block interaction with a
+   * parent window while an owned (modal-style) child window is open.
+   */
+  static final MethodHandle EnableWindow =
+      downcall(USER32, "EnableWindow", FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
+
+  /**
+   * {@code SetForegroundWindow(hWnd) -> BOOL}. Brings the window to the foreground and activates
+   * it. Used to restore focus to the parent window after a modal-style child window closes.
+   */
+  static final MethodHandle SetForegroundWindow =
+      downcall(USER32, "SetForegroundWindow", FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+  /**
    * {@code GetClientRect(hWnd, lpRect) -> BOOL}
    *
    * <p>Fills a {@link #RECT_LAYOUT} buffer with the client-area dimensions of {@code hWnd}. Client
@@ -517,6 +533,27 @@ final class Win32 {
   static void showWindow(MemorySegment hwnd, int cmd) {
     try {
       final var _ = (int) ShowWindow.invokeExact(hwnd, cmd);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Enables or disables mouse/keyboard input to {@code hwnd}. Passing {@code false} blocks the
+   * window from receiving input (clicks produce the system "ding") until re-enabled.
+   */
+  static void enableWindow(MemorySegment hwnd, boolean enable) {
+    try {
+      final var _ = (int) EnableWindow.invokeExact(hwnd, enable ? 1 : 0);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /** Brings {@code hwnd} to the foreground and activates it. */
+  static void setForegroundWindow(MemorySegment hwnd) {
+    try {
+      final var _ = (int) SetForegroundWindow.invokeExact(hwnd);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -49,6 +49,7 @@ final class Win32 {
   private static final SymbolLookup OLE32 = SymbolLookup.libraryLookup("ole32", Arena.global());
 
   // Window style / message constants
+  static final int WS_EX_APPWINDOW = 0x00040000;
   static final int WS_OVERLAPPEDWINDOW = 0x00CF0000;
   static final int WS_POPUP = 0x80000000;
   static final int WS_CHILD = 0x40000000;
@@ -68,6 +69,7 @@ final class Win32 {
   static final int WM_QUIT = 0x0012;
   static final int WM_ACTIVATE = 0x0006;
   static final int WM_GETMINMAXINFO = 0x0024;
+  static final int WM_NCCALCSIZE = 0x0083;
   static final int WM_SETTINGCHANGE = 0x001A;
   static final int WM_APP = 0x8000;
   static final int WA_INACTIVE = 0;

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -71,6 +71,7 @@ final class Win32 {
   static final int WM_APP = 0x8000;
   static final int WA_INACTIVE = 0;
   static final int GWL_STYLE = -16;
+  static final int SWP_NOSIZE = 0x0001;
   static final int SWP_NOMOVE = 0x0002;
   static final int SWP_NOZORDER = 0x0004;
   static final int SWP_NOACTIVATE = 0x0010;
@@ -277,6 +278,15 @@ final class Win32 {
    */
   static final MethodHandle GetClientRect =
       downcall(USER32, "GetClientRect", FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+  /**
+   * {@code GetWindowRect(hWnd, lpRect) -> BOOL}
+   *
+   * <p>Fills a {@link #RECT_LAYOUT} buffer with the screen coordinates of the window, including
+   * non-client area (title bar, borders). Used to determine the full window size for centering.
+   */
+  static final MethodHandle GetWindowRect =
+      downcall(USER32, "GetWindowRect", FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
 
   /**
    * {@code SetWindowPos(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags) -> BOOL}
@@ -564,6 +574,42 @@ final class Win32 {
     try (var a = Arena.ofConfined()) {
       final var _ =
           (int) SetWindowTextW.invokeExact(hwnd, a.allocateFrom(title, StandardCharsets.UTF_16LE));
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Centers {@code hwnd} relative to {@code parentHwnd} when it is non-null, or relative to the
+   * primary screen when {@code parentHwnd} is null/zero. Called once after initial sizing so that
+   * the window appears at the expected position when it is first shown.
+   */
+  static void centerWindow(MemorySegment hwnd, MemorySegment parentHwnd) {
+    try (var a = Arena.ofConfined()) {
+      final var winRect = a.allocate(RECT_LAYOUT);
+      final var _ = (int) GetWindowRect.invokeExact(hwnd, winRect);
+      final int w = winRect.get(JAVA_INT, 8) - winRect.get(JAVA_INT, 0);
+      final int h = winRect.get(JAVA_INT, 12) - winRect.get(JAVA_INT, 4);
+      final int refX, refY, refW, refH;
+      if (parentHwnd.address() != 0) {
+        final var parentRect = a.allocate(RECT_LAYOUT);
+        final var _ = (int) GetWindowRect.invokeExact(parentHwnd, parentRect);
+        refX = parentRect.get(JAVA_INT, 0);
+        refY = parentRect.get(JAVA_INT, 4);
+        refW = parentRect.get(JAVA_INT, 8) - refX;
+        refH = parentRect.get(JAVA_INT, 12) - refY;
+      } else {
+        refX = 0;
+        refY = 0;
+        refW = (int) GetSystemMetrics.invokeExact(SM_CXSCREEN);
+        refH = (int) GetSystemMetrics.invokeExact(SM_CYSCREEN);
+      }
+      final int x = refX + (refW - w) / 2;
+      final int y = refY + (refH - h) / 2;
+      final var _ =
+          (int)
+              SetWindowPos.invokeExact(
+                  hwnd, MemorySegment.NULL, x, y, 0, 0, SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -61,6 +61,7 @@ final class Win32 {
   static final int SW_HIDE = 0;
   static final int SW_SHOW = 5;
   static final int SW_MAXIMIZE = 3;
+  static final int SW_MINIMIZE = 6;
   static final int WM_DESTROY = 0x0002;
   static final int WM_CLOSE = 0x0010;
   static final int WM_SIZE = 0x0005;

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -113,6 +113,9 @@ public final class Win32WebView extends WebviewBase {
 
   private volatile MemorySegment hwnd, hwndMsg, hwndWidget;
 
+  /** Parent window handle */
+  private final MemorySegment parentHwnd;
+
   private volatile ComController controller;
   private volatile ComWebView2 webView2;
 
@@ -165,11 +168,23 @@ public final class Win32WebView extends WebviewBase {
 
   public Win32WebView(
       boolean debug, boolean redirectConsole, int width, int height, boolean borderless) {
+    this(debug, redirectConsole, width, height, borderless, MemorySegment.NULL);
+  }
+
+  public Win32WebView(
+      boolean debug,
+      boolean redirectConsole,
+      int width,
+      int height,
+      boolean borderless,
+      MemorySegment parentHwnd) {
     super(redirectConsole, borderless);
+    this.parentHwnd = parentHwnd == null ? MemorySegment.NULL : parentHwnd;
     Win32.coInitialize();
     Win32.enablePerMonitorDpiAwareness();
     buildWndProcStubs();
     createWindows();
+    if (this.parentHwnd.address() != 0) Win32.enableWindow(this.parentHwnd, false);
     embedWebView2(debug);
     setSizeImpl(width, height);
   }
@@ -200,6 +215,10 @@ public final class Win32WebView extends WebviewBase {
         final var _ = (int) Win32.DestroyWindow.invokeExact(hwnd);
       } catch (final Throwable ignored) {
       }
+    }
+    if (parentHwnd.address() != 0) {
+      Win32.enableWindow(parentHwnd, true);
+      Win32.setForegroundWindow(parentHwnd);
     }
   }
 
@@ -565,7 +584,7 @@ public final class Win32WebView extends WebviewBase {
                   Win32.CW_USEDEFAULT,
                   0,
                   0,
-                  MemorySegment.NULL,
+                  parentHwnd,
                   MemorySegment.NULL,
                   hInstance,
                   MemorySegment.NULL);

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -361,6 +361,12 @@ public final class Win32WebView extends WebviewBase {
   }
 
   @Override
+  public Webview minimizeWindow() {
+    dispatchImpl(() -> Win32.showWindow(hwnd, Win32.SW_MINIMIZE));
+    return this;
+  }
+
+  @Override
   protected void startWindowDragImpl() {
     Win32.startWindowDrag(hwnd);
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -480,6 +480,12 @@ public final class Win32WebView extends WebviewBase {
         }
         return 0;
       }
+      case Win32.WM_NCCALCSIZE -> {
+        // When borderless, return 0 to make the entire window frame the client
+        // area. This hides the title bar and borders visually while preserving WS_OVERLAPPEDWINDOW
+        // behaviours (taskbar button, minimize/maximize/restore, snapping, DPI handling).
+        if (borderless && wParam == 1L) return 0L;
+      }
       case Win32.WM_DPICHANGED -> {
         // Windows pre-computes the correctly scaled rect and passes it in lParam.
         final var suggested = MemorySegment.ofAddress(lParam).reinterpret(16);
@@ -575,14 +581,13 @@ public final class Win32WebView extends WebviewBase {
 
       final var mainCls = "AvajeWebView_" + System.identityHashCode(this);
       registerClass(a, hInstance, mainCls, mainWndProcStub);
-      final var style = borderless ? Win32.WS_POPUP : Win32.WS_OVERLAPPEDWINDOW;
       hwnd =
           (MemorySegment)
               Win32.CreateWindowExW.invokeExact(
                   0,
                   a.allocateFrom(mainCls, StandardCharsets.UTF_16LE),
                   a.allocateFrom("", StandardCharsets.UTF_16LE),
-                  style,
+                  Win32.WS_OVERLAPPEDWINDOW,
                   Win32.CW_USEDEFAULT,
                   Win32.CW_USEDEFAULT,
                   0,

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -113,9 +113,6 @@ public final class Win32WebView extends WebviewBase {
 
   private volatile MemorySegment hwnd, hwndMsg, hwndWidget;
 
-  /** Parent window handle */
-  private final MemorySegment parentHwnd;
-
   private volatile ComController controller;
   private volatile ComWebView2 webView2;
 
@@ -177,16 +174,16 @@ public final class Win32WebView extends WebviewBase {
       int width,
       int height,
       boolean borderless,
-      MemorySegment parentHwnd) {
-    super(redirectConsole, borderless);
-    this.parentHwnd = parentHwnd == null ? MemorySegment.NULL : parentHwnd;
+      MemorySegment parentWindow) {
+    super(redirectConsole, borderless, parentWindow);
     Win32.coInitialize();
     Win32.enablePerMonitorDpiAwareness();
     buildWndProcStubs();
     createWindows();
-    if (this.parentHwnd.address() != 0) Win32.enableWindow(this.parentHwnd, false);
+    if (this.parentWindow.address() != 0) Win32.enableWindow(this.parentWindow, false);
     embedWebView2(debug);
     setSizeImpl(width, height);
+    Win32.centerWindow(hwnd, this.parentWindow);
   }
 
   @Override
@@ -216,9 +213,9 @@ public final class Win32WebView extends WebviewBase {
       } catch (final Throwable ignored) {
       }
     }
-    if (parentHwnd.address() != 0) {
-      Win32.enableWindow(parentHwnd, true);
-      Win32.setForegroundWindow(parentHwnd);
+    if (parentWindow.address() != 0) {
+      Win32.enableWindow(parentWindow, true);
+      Win32.setForegroundWindow(parentWindow);
     }
   }
 
@@ -584,7 +581,7 @@ public final class Win32WebView extends WebviewBase {
                   Win32.CW_USEDEFAULT,
                   0,
                   0,
-                  parentHwnd,
+                  parentWindow,
                   MemorySegment.NULL,
                   hInstance,
                   MemorySegment.NULL);

--- a/avaje-webview/src/main/resources/META-INF/native-image/io.avaje/avaje-webview/reachability-metadata.json
+++ b/avaje-webview/src/main/resources/META-INF/native-image/io.avaje/avaje-webview/reachability-metadata.json
@@ -153,6 +153,13 @@
         ]
       },
       {
+        "returnType": ["jdouble", "jdouble", "jdouble", "jdouble"],
+        "parameterTypes": [
+          "void*",
+          "void*"
+        ]
+      },
+      {
         "returnType": "void",
         "parameterTypes": [
           "void*",

--- a/avaje-webview/src/main/resources/META-INF/native-image/io.avaje/avaje-webview/reachability-metadata.json
+++ b/avaje-webview/src/main/resources/META-INF/native-image/io.avaje/avaje-webview/reachability-metadata.json
@@ -589,6 +589,86 @@
           "void*",
           "void*"
         ]
+      },
+      {
+        "returnType": "jbyte",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "void*"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "void*",
+          "void*",
+          "void*"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "void*",
+          "jlong"
+        ]
+      },
+      {
+        "returnType": "jlong",
+        "parameterTypes": [
+          "jlong",
+          "jlong"
+        ]
+      },
+      {
+        "returnType": "void",
+        "parameterTypes": [
+          "jlong",
+          "void*",
+          "void*",
+          "void*"
+        ]
+      },
+      {
+        "returnType": "void",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "jdouble"
+        ]
+      },
+      {
+        "returnType": "void",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "jint",
+          "jdouble",
+          "jdouble",
+          "jint"
+        ]
+      },
+      {
+        "returnType": "void",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "void*",
+          "jlong"
+        ]
+      },
+      {
+        "returnType": "void*",
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "jdouble",
+          "jdouble",
+          "jdouble",
+          "jdouble"
+        ]
       }
     ]
   }

--- a/examples/hello-world/src/main/java/BorderlessExample.java
+++ b/examples/hello-world/src/main/java/BorderlessExample.java
@@ -27,12 +27,12 @@ String HTML =
       user-select: none;
   }
 
-  .titlebar-close {
+  .titlebar-btn {
       cursor: pointer;
       padding: 4px 10px;
   }
 
-  .titlebar-close:hover {
+  .titlebar-btn:hover {
       background: rgba(255, 255, 255, 0.2);
   }
 
@@ -44,7 +44,10 @@ String HTML =
 <body>
   <div class="titlebar" id="titlebar">
     <span>Borderless Window</span>
-    <span class="titlebar-close" onclick="closeWindow()">✕</span>
+    <div>
+      <span class="titlebar-btn" onclick="minimizeWindow()">−</span>
+      <span class="titlebar-btn" onclick="closeWindow()">✕</span>
+    </div>
   </div>
   <div class="content">
     <p>This window has no native title bar or border.</p>
@@ -55,9 +58,13 @@ String HTML =
     // Native decorations are gone (see .borderless(true) below), so dragging the
     // colored bar has to start a native window-move ourselves via a bound function.
     document.getElementById('titlebar').addEventListener('mousedown', event => {
-      if (event.button !== 0 || event.target.closest('.titlebar-close')) return;
+      if (event.button !== 0 || event.target.closest('.titlebar-btn')) return;
       startDrag();
     });
+
+    function minimizeWindow() {
+      minimizeApp();
+    }
 
     function closeWindow() {
       closeApp();
@@ -81,6 +88,13 @@ void main() {
       "startDrag",
       req -> {
         webview.startWindowDrag();
+        return null;
+      });
+
+  webview.bind(
+      "minimizeApp",
+      req -> {
+        webview.minimizeWindow();
         return null;
       });
 

--- a/examples/hello-world/src/main/java/ChildWindowExample.java
+++ b/examples/hello-world/src/main/java/ChildWindowExample.java
@@ -1,0 +1,111 @@
+import io.avaje.webview.Webview;
+
+String MAIN_HTML =
+"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Child Window Demo</title>
+  <style>
+  body {
+      font-family: system-ui, sans-serif;
+      padding: 40px;
+  }
+
+  button {
+      padding: 10px 20px;
+      background: #667eea;
+      color: white;
+      border: none;
+      cursor: pointer;
+  }
+  </style>
+</head>
+<body>
+  <h1>Main Window</h1>
+  <p>Click the button to open a modal child (dialog) window.</p>
+  <p>The main window is blocked - clicking it does nothing - until the child closes.</p>
+  <button onclick="openDialog()">Open Dialog</button>
+
+  <script>
+    function openDialog() {
+      openChild();
+    }
+  </script>
+</body>
+</html>
+""";
+
+String CHILD_HTML =
+"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dialog</title>
+  <style>
+  body {
+      font-family: system-ui, sans-serif;
+      padding: 30px;
+      text-align: center;
+  }
+
+  button {
+      padding: 10px 20px;
+      background: #667eea;
+      color: white;
+      border: none;
+      cursor: pointer;
+  }
+  </style>
+</head>
+<body>
+  <h2>Modal Dialog</h2>
+  <p>The main window stays inert while this window is open.</p>
+  <button onclick="done()">Done</button>
+
+  <script>
+    function done() {
+      closeDialog();
+    }
+  </script>
+</body>
+</html>
+""";
+
+void main() {
+  Webview main =
+      Webview.builder().title("Main Window").width(500).height(300).html(MAIN_HTML).build();
+
+  main.bind(
+      "openChild",
+      req -> {
+        // Build and run the child on its own platform thread - each Webview.run() blocks
+        // its calling thread until that window closes, so the child needs its own thread
+        // while the main window keeps pumping on this one.
+        Thread.ofPlatform()
+            .start(
+                () -> {
+                  try (Webview child =
+                      Webview.builder()
+                          .title("Please wait")
+                          .width(320)
+                          .height(180)
+                          .parent(main) // disables `main` until this window closes
+                          .html(CHILD_HTML)
+                          .build()) {
+                    child.bind(
+                        "closeDialog",
+                        _ -> {
+                          child.dispatch(child::close);
+                          return null;
+                        });
+                    child.run();
+                  }
+                });
+        return null;
+      });
+
+  main.run();
+}


### PR DESCRIPTION
  Add child/modal window support
 
- Adds `Builder.parent(Webview parent)` that makes a window behave like a modal dialog owned by another window. While the child is open, the parent is blocked from receiving input.
- adds minimize support
- all windows should now appear in the center of the screen (child windows should appear in the center of the parent)

##  Implementation per platform:

### Windows 
Passes the parent HWND to CreateWindowEx, calls EnableWindow(parent, false) on construction and EnableWindow(parent, true) + SetForegroundWindow on close.

### Linux 

Calls `gtk_window_set_transient_for` +` gtk_window_set_moda`l for window-manager stacking, and `gtk_widget_set_sensitive(parent, false/true)` to block/restore input.

 ###  macOS
Uses `[NSWindow addChildWindow:ordered:]` for stacking. Cocoa has no built-in input-blocking, so a transparent `NSView subclass (JavaWebviewClickGuard_*`) is synthesized and installed as an overlay on the parent's content view. Clicks into the parent are swallowed by the guard and redirect attention to the child with a brief opacity flash.

Also calls [NSWindow center] so new windows appear centered rather than in the raw bottom-left origin.