### PR TITLE
 Add transparent windows, window sizing/maximize controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ Webview webview = Webview.builder()
     .height(800)
     .enableDeveloperTools(true) // Enable right-click > Inspect
     .resizable(false)           // Lock to width/height, no user resize
+    .maximizable(false)         // Hide/disable the maximize button (ignored on Linux)
     .maximize(true)             // Start maximized (ignored if fullscreen(true))
     .fullscreen(true)           // Start fullscreen, takes precedence over maximize
+    .minSize(600, 400)          // Minimum size the user can resize to
+    .maxSize(1920, 1080)        // Maximum size the user can resize to
     .build();
 
 // Set window constraints after creation
@@ -121,6 +124,20 @@ Webview webview = Webview.builder()
 - **macOS**: uses a transparent, hidden title bar so the window shadow/border are retained.
 - **Linux**: the outline flag has no effect.
 
+### Transparent Windows
+
+```java
+Webview webview = Webview.builder()
+    .borderless(true)
+    .transparent(true) // Window background is see-through wherever the page doesn't paint
+    .html("<body style='background:transparent'>...</body>")
+    .build();
+```
+
+Combine with a page that only paints part of its area (e.g. `background: transparent` plus a
+`backdrop-filter: blur(...)` card) to get a native-looking translucent window. Usually paired with
+`borderless(true)` so there's no opaque title bar left behind.
+
 ### Child Windows
 
 ```java
@@ -134,6 +151,15 @@ Webview child = Webview.builder()
 
 The parent window is disabled (blocked from mouse/keyboard input) as soon as the child is built,
 and re-enabled automatically when the child closes.
+
+Pass `true` as a second argument to `parent(...)` to keep the parent locked to the child's
+position while dragging (Windows and macOS only currently):
+
+```java
+Webview child = Webview.builder()
+    .parent(parent, true) // parent moves with the child when dragged
+    .build();
+```
 
 ### Set Window Icon
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Webview webview = Webview.builder()
     .width(1200)
     .height(800)
     .enableDeveloperTools(true) // Enable right-click > Inspect
+    .resizable(false)           // Lock to width/height, no user resize
+    .maximize(true)             // Start maximized (ignored if fullscreen(true))
+    .fullscreen(true)           // Start fullscreen, takes precedence over maximize
     .build();
 
 // Set window constraints after creation
@@ -94,6 +97,43 @@ webview.fullscreen();
 // Dark mode
 webview.setDarkAppearance(true);
 ```
+
+### Borderless Windows
+
+```java
+Webview webview = Webview.builder()
+    .borderless(true) // No title bar, borders, or minimize/maximize/close buttons
+    .build();
+```
+
+Combine with `webview.startWindowDrag()` to implement a custom draggable title bar, since a
+borderless window has no native title bar for the user to grab.
+
+Keep the native outline (drop shadow and thin border) while still removing the title bar:
+
+```java
+Webview webview = Webview.builder()
+    .borderless(true, true) // outline=true keeps the native border/shadow
+    .build();
+```
+
+- **Windows**: only the title bar area is removed; left/right/bottom borders and the DWM shadow remain.
+- **macOS**: uses a transparent, hidden title bar so the window shadow/border are retained.
+- **Linux**: the outline flag has no effect.
+
+### Child Windows
+
+```java
+Webview parent = Webview.builder().title("Parent").build();
+
+Webview child = Webview.builder()
+    .title("Child")
+    .parent(parent) // Blocks the parent's input until this window closes
+    .build();
+```
+
+The parent window is disabled (blocked from mouse/keyboard input) as soon as the child is built,
+and re-enabled automatically when the child closes.
 
 ### Set Window Icon
 
@@ -218,8 +258,14 @@ All subsequent windows dispatch their init to that thread automatically.
 
 ## Console output
 
-`console.log`, `console.warn`, `console.error`, etc. are automatically forwarded to
-`java.lang.System.Logger` under the name `io.avaje.webview`. Configure your logging
+```java
+Webview webview = Webview.builder()
+    .redirectConsole(true) // Defaults to false
+    .build();
+```
+
+With `redirectConsole(true)`, `console.log`, `console.warn`, `console.error`, etc. are forwarded
+to `java.lang.System.Logger` under the name `io.avaje.webview`. Configure your logging
 framework to see webview JS console output.
 
 ## Notable changes from upstream

--- a/avaje-webview/pom.xml
+++ b/avaje-webview/pom.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-      <groupId>io.avaje.webview</groupId>
-      <artifactId>avaje-webview-parent</artifactId>
-      <version>0.26</version>
-    </parent>
-    
-    <artifactId>avaje-webview</artifactId>
+	<parent>
+		<groupId>io.avaje.webview</groupId>
+		<artifactId>avaje-webview-parent</artifactId>
+		<version>0.26</version>
+	</parent>
 
-    <name>avaje-webview</name>
-    <description>FFM Wrapper over webview</description>
+	<artifactId>avaje-webview</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>io.avaje</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.8</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+	<name>avaje-webview</name>
+	<description>FFM Wrapper over webview</description>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-XX:+IgnoreUnrecognizedVMOptions -XstartOnFirstThread</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<dependencies>
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>junit</artifactId>
+			<version>1.8</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-XX:+IgnoreUnrecognizedVMOptions
+						-XstartOnFirstThread</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/avaje-webview/src/main/java/io/avaje/webview/Webview.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/Webview.java
@@ -352,6 +352,18 @@ public interface Webview extends Closeable, Runnable {
     Builder parent(Webview parent);
 
     /**
+     * Marks this window as owned by {@code parent} and optionally locks their positions together.
+     *
+     * <p>When {@code moveParentWithChild} is {@code true}, dragging the child window also moves
+     * the parent by the same delta, keeping them visually locked.
+     *
+     * @param parent the {@code Webview} that should be blocked while this window is open
+     * @param moveParentWithChild {@code true} to synchronise parent position with child
+     * @return this builder
+     */
+    Builder parent(Webview parent, boolean moveParentWithChild);
+
+    /**
      * Maximizes the window immediately after it is shown. Defaults to {@code false}.
      *
      * @param maximize {@code true} to start maximized
@@ -369,6 +381,35 @@ public interface Webview extends Closeable, Runnable {
     Builder fullscreen(boolean fullscreen);
 
     /**
+     * Controls whether the maximize button is shown on the native title bar. Defaults to {@code
+     * true}.
+     *
+     * <p>On Linux (GTK4) this has no effect.
+     *
+     * @param maximizable {@code false} to hide/disable the maximize button
+     * @return this builder
+     */
+    Builder maximizable(boolean maximizable);
+
+    /**
+     * Sets the minimum size the user can resize the window to.
+     *
+     * @param width minimum width in pixels
+     * @param height minimum height in pixels
+     * @return this builder
+     */
+    Builder minSize(int width, int height);
+
+    /**
+     * Sets the maximum size the user can resize the window to.
+     *
+     * @param width maximum width in pixels
+     * @param height maximum height in pixels
+     * @return this builder
+     */
+    Builder maxSize(int width, int height);
+
+    /**
      * Controls whether the user can resize the window. Defaults to {@code true}.
      *
      * <p>When set to {@code false}, the window is created at the specified {@link #width(int)} and
@@ -379,6 +420,15 @@ public interface Webview extends Closeable, Runnable {
      * @return this builder
      */
     Builder resizable(boolean resizable);
+
+    /**
+     * Enables a transparent window background so web content with a transparent or
+     * semi-transparent CSS background shows through to the desktop. Defaults to {@code false}.
+     *
+     * @param transparent {@code true} to enable transparency
+     * @return this builder
+     */
+    Builder transparent(boolean transparent);
 
     /**
      * Builds a Webview using the configuration

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBase.java
@@ -73,14 +73,23 @@ public abstract sealed class WebviewBase implements Webview
   private final boolean redirectConsole;
   protected final boolean borderless;
   protected final boolean outline;
+  protected final boolean transparent;
   protected final MemorySegment parentWindow;
+  protected final boolean moveParentWithChild;
 
   protected WebviewBase(
-      boolean redirectConsole, boolean borderless, boolean outline, MemorySegment parentWindow) {
+      boolean redirectConsole,
+      boolean borderless,
+      boolean outline,
+      boolean transparent,
+      MemorySegment parentWindow,
+      boolean moveParentWithChild) {
     this.redirectConsole = redirectConsole;
     this.borderless = borderless;
     this.outline = outline;
+    this.transparent = transparent;
     this.parentWindow = parentWindow != null ? parentWindow : MemorySegment.NULL;
+    this.moveParentWithChild = moveParentWithChild;
   }
 
   // JS bridge state, all mutations to userScripts/bindScriptIdx must happen on the main thread
@@ -170,6 +179,10 @@ public abstract sealed class WebviewBase implements Webview
   @Override
   public void setFixedSize(int width, int height) {
     dispatchImpl(() -> setFixedSizeImpl(width, height));
+  }
+
+  void disableMaximize() {
+    dispatchImpl(this::disableMaximizeImpl);
   }
 
   @Override
@@ -291,6 +304,8 @@ public abstract sealed class WebviewBase implements Webview
   protected abstract void setMaxSizeImpl(int width, int height);
 
   protected abstract void setFixedSizeImpl(int width, int height);
+
+  protected abstract void disableMaximizeImpl();
 
   protected abstract void setHtmlImpl(String html);
 

--- a/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/WebviewBuilder.java
@@ -22,6 +22,10 @@ final class WebviewBuilder implements Builder {
   private boolean maximize;
   private boolean fullscreen;
   private boolean resizable = true;
+  private boolean maximizable = true;
+  private boolean moveParentWithChild;
+  private boolean transparent;
+  private int minWidth, minHeight, maxWidth, maxHeight = -1;
 
   WebviewBuilder() {}
 
@@ -92,6 +96,13 @@ final class WebviewBuilder implements Builder {
   }
 
   @Override
+  public WebviewBuilder parent(Webview parent, boolean moveParentWithChild) {
+    this.parent = parent.nativeWindowPointer();
+    this.moveParentWithChild = moveParentWithChild;
+    return this;
+  }
+
+  @Override
   public WebviewBuilder maximize(boolean maximize) {
     this.maximize = maximize;
     return this;
@@ -104,14 +115,40 @@ final class WebviewBuilder implements Builder {
   }
 
   @Override
+  public WebviewBuilder maximizable(boolean maximizable) {
+    this.maximizable = maximizable;
+    return this;
+  }
+
+  @Override
+  public WebviewBuilder minSize(int width, int height) {
+    this.minWidth = width;
+    this.minHeight = height;
+    return this;
+  }
+
+  @Override
+  public WebviewBuilder maxSize(int width, int height) {
+    this.maxWidth = width;
+    this.maxHeight = height;
+    return this;
+  }
+
+  @Override
   public WebviewBuilder resizable(boolean resizable) {
     this.resizable = resizable;
     return this;
   }
 
   @Override
+  public WebviewBuilder transparent(boolean transparent) {
+    this.transparent = transparent;
+    return this;
+  }
+
+  @Override
   public Webview build() {
-    final var view = createForPlatform();
+    final WebviewBase view = createForPlatform();
     if (title != null) view.setTitle(title);
     if (url != null) {
       view.navigate(url);
@@ -127,21 +164,25 @@ final class WebviewBuilder implements Builder {
     }
     if (!resizable) {
       view.setFixedSize(width, height);
+    } else {
+      if (!maximizable) view.disableMaximize();
+      if (minWidth > 0) view.setMinSize(minWidth, minHeight);
+      if (maxWidth > 0) view.setMaxSize(maxWidth, maxHeight);
     }
     return view;
   }
 
-  private Webview createForPlatform() {
+  private WebviewBase createForPlatform() {
     final var os = System.getProperty("os.name", "").toLowerCase();
     if (os.contains("win"))
       return new Win32WebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, outline, parent);
+          enableDeveloperTools, redirectConsole, width, height, borderless, outline, transparent, parent, moveParentWithChild);
     if (os.contains("mac"))
       return new CocoaWebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, outline, parent);
+          enableDeveloperTools, redirectConsole, width, height, borderless, outline, transparent, parent, moveParentWithChild);
     if (os.contains("linux"))
       return new GtkWebView(
-          enableDeveloperTools, redirectConsole, width, height, borderless, outline, parent);
+          enableDeveloperTools, redirectConsole, width, height, borderless, outline, transparent, parent, moveParentWithChild);
     throw new UnsupportedOperationException(
         "Unsupported platform: " + System.getProperty("os.name"));
   }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/Gtk4.java
@@ -3,6 +3,7 @@ package io.avaje.webview.linux;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -266,6 +267,63 @@ final class Gtk4 {
    */
   private static final MethodHandle GTK_SETTINGS_GET_DEFAULT =
       downcall("gtk_settings_get_default", FunctionDescriptor.of(ADDRESS));
+
+  /**
+   * {@code GTK_STYLE_PROVIDER_PRIORITY_APPLICATION} - the priority used for app-level CSS so it
+   * overrides the active theme's stylesheet but can still be overridden by user themes/settings.
+   */
+  private static final int GTK_STYLE_PROVIDER_PRIORITY_APPLICATION = 600;
+
+  /**
+   * {@code gdk_display_get_default() -> GdkDisplay*}
+   *
+   * <p>Returns the default {@code GdkDisplay} for the process; used as the target for a
+   * process-wide CSS provider rather than requiring a realized widget to look one up.
+   */
+  private static final MethodHandle GDK_DISPLAY_GET_DEFAULT =
+      downcall("gdk_display_get_default", FunctionDescriptor.of(ADDRESS));
+
+  /**
+   * {@code gtk_widget_add_css_class(GtkWidget* widget, const char* css_class) -> void}
+   *
+   * <p>Adds a CSS style class to a widget so a targeted stylesheet rule (e.g. {@code
+   * .webview-transparent}) can match only this widget instance rather than every window.
+   */
+  private static final MethodHandle GTK_WIDGET_ADD_CSS_CLASS =
+      downcall("gtk_widget_add_css_class", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+
+  /**
+   * {@code gtk_css_provider_new() -> GtkCssProvider*}
+   *
+   * <p>Creates a new, empty CSS provider. Returns a full (non-floating) GObject reference.
+   */
+  private static final MethodHandle GTK_CSS_PROVIDER_NEW =
+      downcall("gtk_css_provider_new", FunctionDescriptor.of(ADDRESS));
+
+  /**
+   * {@code gtk_css_provider_load_from_data(GtkCssProvider* provider, const char* data, gssize
+   * length) -> void}
+   *
+   * <p>Parses {@code data} as CSS and loads it into {@code provider}. GTK4 dropped the {@code
+   * GError**} out-param that GTK3 had; parse errors are reported asynchronously via the
+   * provider's {@code "parsing-error"} signal, which we don't connect to since our stylesheet is a
+   * fixed, known-valid literal.
+   */
+  private static final MethodHandle GTK_CSS_PROVIDER_LOAD_FROM_DATA =
+      downcall(
+          "gtk_css_provider_load_from_data", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_LONG));
+
+  /**
+   * {@code gtk_style_context_add_provider_for_display(GdkDisplay* display, GtkStyleProvider*
+   * provider, guint priority) -> void}
+   *
+   * <p>Registers {@code provider} for every widget on {@code display}. The display retains its own
+   * reference, so the caller may drop its reference immediately after this call.
+   */
+  private static final MethodHandle GTK_STYLE_CONTEXT_ADD_PROVIDER_FOR_DISPLAY =
+      downcall(
+          "gtk_style_context_add_provider_for_display",
+          FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_INT));
 
   private static MethodHandle downcall(String sym, FunctionDescriptor desc) {
     return LINKER.downcallHandle(
@@ -564,6 +622,37 @@ final class Gtk4 {
   static MemorySegment gtkSettingsGetDefault() {
     try {
       return (MemorySegment) GTK_SETTINGS_GET_DEFAULT.invokeExact();
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Makes {@code window}'s background see-through so that whatever is behind it in the compositor
+   * (desktop, other windows) shows through wherever neither the window chrome nor the page content
+   * paints an opaque pixel.
+   *
+   * <p>This only affects the GTK-drawn window background; the caller must separately clear
+   * WebKit's own opaque base fill via {@link WebKit6#webkitWebViewSetBackgroundColor}, otherwise
+   * the page itself still renders an opaque white rectangle over the (now transparent) window.
+   *
+   * <p>Requires a compositor that supports an alpha channel for client windows: this works
+   * out-of-the-box on Wayland and on X11 with a compositing manager (e.g. picom) running. Without
+   * one, the "transparent" areas fall back to opaque black.
+   *
+   * @param window a {@code GtkWindow*}, not yet required to be realized
+   */
+  static void gtkMakeWindowTransparent(MemorySegment window) {
+    try (var a = Arena.ofConfined()) {
+      GTK_WIDGET_ADD_CSS_CLASS.invokeExact(window, (MemorySegment) a.allocateFrom("webview-transparent"));
+      final var provider = (MemorySegment) GTK_CSS_PROVIDER_NEW.invokeExact();
+      final var css = a.allocateFrom("window.webview-transparent { background-color: rgba(0,0,0,0); }");
+      GTK_CSS_PROVIDER_LOAD_FROM_DATA.invokeExact(provider, (MemorySegment) css, (long) -1);
+      final var display = (MemorySegment) GDK_DISPLAY_GET_DEFAULT.invokeExact();
+      GTK_STYLE_CONTEXT_ADD_PROVIDER_FOR_DISPLAY.invokeExact(
+          display, provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+      // add_provider_for_display takes its own reference; drop ours now.
+      GLib.gObjectUnref(provider);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/GtkWebView.java
@@ -82,8 +82,10 @@ public final class GtkWebView extends WebviewBase {
       int height,
       boolean borderless,
       boolean outline,
-      MemorySegment parentWindow) {
-    super(redirectConsole, borderless, outline, parentWindow);
+      boolean transparent,
+      MemorySegment parentWindow,
+      boolean moveParentWithChild) {
+    super(redirectConsole, borderless, outline, transparent, parentWindow, moveParentWithChild);
     this.initialWidth = width;
     this.initialHeight = height;
     openWindows.incrementAndGet();
@@ -219,6 +221,11 @@ public final class GtkWebView extends WebviewBase {
   protected void setMaxSizeImpl(int width, int height) {
     // GTK4 removed geometry hints
     // No equivalent exists in GTK4 without writing a custom size-allocate handler.
+  }
+
+  @Override
+  protected void disableMaximizeImpl() {
+    // GTK4 has no API to disable only the maximize button without subclassing or CSS hacks
   }
 
   @Override
@@ -468,6 +475,7 @@ public final class GtkWebView extends WebviewBase {
   private void initWindowAndWebView(boolean debug) {
     window = Gtk4.gtkWindowNew();
     if (borderless) Gtk4.gtkWindowSetDecorated(window, false);
+    if (transparent) Gtk4.gtkMakeWindowTransparent(window);
     GLib.gSignalConnect(window, "destroy", destroyStub, MemorySegment.NULL);
     if (parentWindow.address() != 0L) {
       Gtk4.gtkWindowSetTransientFor(window, parentWindow);
@@ -480,6 +488,7 @@ public final class GtkWebView extends WebviewBase {
     // set). g_object_ref_sink atomically claims ownership by clearing the floating flag, giving us
     // a stable +1 reference that we control.
     GLib.gObjectRefSink(webView);
+    if (transparent) WebKit6.webkitWebViewSetBackgroundColor(webView, 0f, 0f, 0f, 0f);
 
     ucManager = WebKit6.webkitWebViewGetUserContentManager(webView);
     try (var a = Arena.ofConfined()) {

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/LinuxHelper.java
@@ -1,6 +1,7 @@
 package io.avaje.webview.linux;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 
 import io.avaje.webview.Webview;
@@ -42,8 +43,7 @@ final class LinuxHelper {
       if (settings.address() == 0L) throw new RuntimeException("Failed to get GTK settings");
       final var propertyName =
           arena.allocateFrom("gtk-application-prefer-dark-theme", StandardCharsets.UTF_8);
-      GLib.gObjectSet(
-          settings, propertyName, shouldBeDark ? 1 : 0, java.lang.foreign.MemorySegment.NULL);
+      GLib.gObjectSet(settings, propertyName, shouldBeDark ? 1 : 0, MemorySegment.NULL);
     }
   }
 }

--- a/avaje-webview/src/main/java/io/avaje/webview/linux/WebKit6.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/linux/WebKit6.java
@@ -1,6 +1,7 @@
 package io.avaje.webview.linux;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
@@ -330,6 +331,19 @@ final class WebKit6 {
   private static final MethodHandle JSC_VALUE_TO_STRING =
       downcall("jsc_value_to_string", FunctionDescriptor.of(ADDRESS, ADDRESS));
 
+  /**
+   * {@code webkit_web_view_set_background_color(WebKitWebView* wv, const GdkRGBA* rgba) -> void}
+   *
+   * <p>Sets the base color the web view paints beneath page content before anything is
+   * rendered/composited. Passing an RGBA color with {@code alpha=0} stops WebKit from painting its
+   * default opaque white base, which is required for the GTK window behind it to show through.
+   *
+   * <p>{@code GdkRGBA} is a plain C struct of four {@code float}s: {@code red, green, blue, alpha}
+   * (16 bytes total, no padding), passed by pointer.
+   */
+  private static final MethodHandle WEBKIT_WEB_VIEW_SET_BACKGROUND_COLOR =
+      downcall("webkit_web_view_set_background_color", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+
   private static MethodHandle downcall(String sym, FunctionDescriptor desc) {
     return LINKER.downcallHandle(
         LOOKUP
@@ -642,6 +656,30 @@ final class WebKit6 {
     // Must free with g_free, not the JVM GC - this pointer came from GLib's allocator.
     GLib.gFree(raw);
     return s;
+  }
+
+  /**
+   * Sets the base color painted beneath page content, e.g. {@code (0,0,0,0)} for fully transparent
+   * so a transparent GTK window shows through wherever the page itself doesn't paint.
+   *
+   * @param wv a {@code WebKitWebView*}
+   * @param red red channel, {@code 0.0}-{@code 1.0}
+   * @param green green channel, {@code 0.0}-{@code 1.0}
+   * @param blue blue channel, {@code 0.0}-{@code 1.0}
+   * @param alpha alpha channel, {@code 0.0} (transparent) - {@code 1.0} (opaque)
+   */
+  static void webkitWebViewSetBackgroundColor(
+      MemorySegment wv, float red, float green, float blue, float alpha) {
+    try (var a = Arena.ofConfined()) {
+      final var rgba = a.allocate(4 * JAVA_FLOAT.byteSize());
+      rgba.set(JAVA_FLOAT, 0, red);
+      rgba.set(JAVA_FLOAT, 4, green);
+      rgba.set(JAVA_FLOAT, 8, blue);
+      rgba.set(JAVA_FLOAT, 12, alpha);
+      WEBKIT_WEB_VIEW_SET_BACKGROUND_COLOR.invokeExact(wv, (MemorySegment) rgba);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
   }
 
   private WebKit6() {}

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/CocoaWebView.java
@@ -26,6 +26,7 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
@@ -181,6 +182,10 @@ public final class CocoaWebView extends WebviewBase {
   private final AtomicBoolean windowClosed = new AtomicBoolean(false);
   private final CountDownLatch windowClosedLatch = new CountDownLatch(1);
 
+  private double childLastX, childLastY;
+  private boolean syncMoving;
+  private volatile boolean disableZoom;
+
   /**
    * Arena that owns the Panama upcall stubs (drainStub, script handler stub, window delegate stub).
    */
@@ -197,8 +202,10 @@ public final class CocoaWebView extends WebviewBase {
       int height,
       boolean borderless,
       boolean outline,
-      MemorySegment parentWindow) {
-    super(redirectConsole, borderless, outline, parentWindow);
+      boolean transparent,
+      MemorySegment parentWindow,
+      boolean moveParentWithChild) {
+    super(redirectConsole, borderless, outline, transparent, parentWindow, moveParentWithChild);
     openWindows.incrementAndGet();
     buildDrainStub();
 
@@ -322,6 +329,42 @@ public final class CocoaWebView extends WebviewBase {
     try (var a = Arena.ofConfined()) {
       MSG_SEND_SET_SIZE.invokeExact(
           nsWindow, sel(a, "setMaxSize:"), (double) width, (double) height);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  @Override
+  protected void disableMaximizeImpl() {
+    disableZoom = true;
+    if (closed) return;
+    try (var a = Arena.ofConfined()) {
+      final var buttonMh =
+          Linker.nativeLinker()
+              .downcallHandle(
+                  MSG_SEND_ADDR,
+                  FunctionDescriptor.of(
+                      ValueLayout.ADDRESS,
+                      ValueLayout.ADDRESS,
+                      ValueLayout.ADDRESS,
+                      ValueLayout.JAVA_LONG));
+      final var hideMh =
+          Linker.nativeLinker()
+              .downcallHandle(
+                  MSG_SEND_ADDR,
+                  FunctionDescriptor.ofVoid(
+                      ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+      final var zoomBtn =
+          (MemorySegment) buttonMh.invokeExact(nsWindow, sel(a, "standardWindowButton:"), 2L);
+      if (zoomBtn.address() != 0) hideMh.invokeExact(zoomBtn, sel(a, "setHidden:"), 1);
+
+      final long behavior =
+          ((MemorySegment) MSG_SEND_0.invokeExact(nsWindow, sel(a, "collectionBehavior"))).address();
+      Linker.nativeLinker()
+          .downcallHandle(
+              MSG_SEND_ADDR,
+              FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG))
+          .invokeExact(nsWindow, sel(a, "setCollectionBehavior:"), behavior | (1L << 9));
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }
@@ -536,6 +579,47 @@ public final class CocoaWebView extends WebviewBase {
       }
     }
     windowClosedLatch.countDown();
+  }
+
+  /**
+   * Fires whenever the child window moves. Moves the parent window by the same delta so they stay
+   * locked together. Ignores movements caused by the parent dragging the child (via addChildWindow)
+   * by comparing both deltas and skipping when they match.
+   */
+  @SuppressWarnings("unused")
+  public void onWindowDidMove(MemorySegment self, MemorySegment cmd, MemorySegment notification) {
+    if (syncMoving || parentWindow.address() == 0) return;
+    try (var a = Arena.ofConfined()) {
+      final var frameSel = sel(a, "frame");
+      final var cf =
+          (MemorySegment)
+              ObjC.MSG_SEND_GET_FRAME.invokeExact((SegmentAllocator) a, nsWindow, frameSel);
+      final double cx = cf.get(ValueLayout.JAVA_DOUBLE, 0), cy = cf.get(ValueLayout.JAVA_DOUBLE, 8);
+      final double cdx = cx - childLastX, cdy = cy - childLastY;
+      childLastX = cx;
+      childLastY = cy;
+
+      if (cdx == 0 && cdy == 0) return;
+
+      final var pf =
+          (MemorySegment)
+              ObjC.MSG_SEND_GET_FRAME.invokeExact((SegmentAllocator) a, parentWindow, frameSel);
+      final double px = pf.get(ValueLayout.JAVA_DOUBLE, 0), py = pf.get(ValueLayout.JAVA_DOUBLE, 8);
+
+      syncMoving = true;
+      try {
+        ObjC.MSG_SEND_SET_SIZE.invokeExact(parentWindow, sel(a, "setFrameOrigin:"), px + cdx, py + cdy);
+      } finally {
+        syncMoving = false;
+      }
+    } catch (final Throwable ignored) {
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public byte onWindowShouldZoom(
+      MemorySegment self, MemorySegment cmd, MemorySegment window, MemorySegment frame) {
+    return disableZoom ? (byte) 0 : (byte) 1;
   }
 
   /**
@@ -758,6 +842,36 @@ public final class CocoaWebView extends WebviewBase {
         }
       }
 
+      if (transparent) {
+        final var boolMh =
+            Linker.nativeLinker()
+                .downcallHandle(
+                    MSG_SEND_ADDR,
+                    FunctionDescriptor.ofVoid(
+                        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+        boolMh.invokeExact(nsWindow, sel(a, "setOpaque:"), 0);
+        sendVoid1(nsWindow, sel(a, "setBackgroundColor:"),
+            send0(ObjC.getClass(a, "NSColor"), sel(a, "clearColor")));
+        // Prevent WKWebView from painting its default white fill.
+        final var falseNum =
+            (MemorySegment)
+                Linker.nativeLinker()
+                    .downcallHandle(
+                        MSG_SEND_ADDR,
+                        FunctionDescriptor.of(
+                            ValueLayout.ADDRESS,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.ADDRESS,
+                            ValueLayout.JAVA_INT))
+                    .invokeExact(ObjC.getClass(a, "NSNumber"), sel(a, "numberWithBool:"), 0);
+        Linker.nativeLinker()
+            .downcallHandle(
+                MSG_SEND_ADDR,
+                FunctionDescriptor.ofVoid(
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS))
+            .invokeExact(wkWebView, sel(a, "setValue:forKey:"), falseNum, nsString(a, "drawsBackground"));
+      }
+
       if (parentWindow.address() != 0) {
         MacOSHelper.centerOnParent(nsWindow, parentWindow);
       } else {
@@ -770,7 +884,14 @@ public final class CocoaWebView extends WebviewBase {
       sendVoid1(wkWebView, sel(a, "setNavigationDelegate:"), createNavigationDelegate(a));
 
       if (parentWindow.address() != 0) {
-        MacOSHelper.addChildWindow(parentWindow, nsWindow);
+        if (!moveParentWithChild) {
+          MacOSHelper.addChildWindow(parentWindow, nsWindow);
+        } else {
+          final var frameSel = sel(a, "frame");
+          final var cf = (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact((SegmentAllocator) a, nsWindow, frameSel);
+          childLastX = cf.get(ValueLayout.JAVA_DOUBLE, 0);
+          childLastY = cf.get(ValueLayout.JAVA_DOUBLE, 8);
+        }
         parentClickGuard = createClickGuardView(a);
         MacOSHelper.installFillAutoresizeMask(parentClickGuard);
         MacOSHelper.attachClickGuard(parentWindow, parentClickGuard);
@@ -818,6 +939,59 @@ public final class CocoaWebView extends WebviewBase {
           (byte)
               CLASS_ADD_METHOD.invokeExact(
                   cls, sel(a, "windowWillClose:"), stub, a.allocateFrom("v@:@"));
+
+      final var shouldZoomMh =
+          MethodHandles.lookup()
+              .findVirtual(
+                  CocoaWebView.class,
+                  "onWindowShouldZoom",
+                  MethodType.methodType(
+                      byte.class,
+                      MemorySegment.class,
+                      MemorySegment.class,
+                      MemorySegment.class,
+                      MemorySegment.class))
+              .bindTo(this);
+      final var shouldZoomStub =
+          Linker.nativeLinker()
+              .upcallStub(
+                  shouldZoomMh,
+                  FunctionDescriptor.of(
+                      ValueLayout.JAVA_BYTE,
+                      ValueLayout.ADDRESS,
+                      ValueLayout.ADDRESS,
+                      ValueLayout.ADDRESS,
+                      ObjC.NS_RECT_LAYOUT),
+                  callbackArena);
+      final var _ =
+          (byte)
+              CLASS_ADD_METHOD.invokeExact(
+                  cls,
+                  sel(a, "windowShouldZoom:toFrame:"),
+                  shouldZoomStub,
+                  a.allocateFrom("c@:@{NSRect={NSPoint=dd}{NSSize=dd}}"));
+
+      if (moveParentWithChild && parentWindow.address() != 0) {
+        final var moveMh =
+            MethodHandles.lookup()
+                .findVirtual(
+                    CocoaWebView.class,
+                    "onWindowDidMove",
+                    MethodType.methodType(
+                        void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class))
+                .bindTo(this);
+        final var moveStub =
+            Linker.nativeLinker()
+                .upcallStub(
+                    moveMh,
+                    FunctionDescriptor.ofVoid(
+                        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+                    callbackArena);
+        final var _ =
+            (byte)
+                CLASS_ADD_METHOD.invokeExact(
+                    cls, sel(a, "windowDidMove:"), moveStub, a.allocateFrom("v@:@"));
+      }
 
       REGISTER_CLASS_PAIR.invokeExact(cls);
       return (MemorySegment) CLASS_CREATE_INSTANCE.invokeExact(cls, 0L);

--- a/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/macos/MacOSHelper.java
@@ -15,6 +15,7 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 import java.nio.file.Path;
 
@@ -146,8 +147,8 @@ final class MacOSHelper {
     try (var a = Arena.ofConfined()) {
       final var frameSel = sel(a, "frame");
       final var pFrame =
-          (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact(parentWindow, frameSel);
-      final var cFrame = (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact(nsWindow, frameSel);
+          (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact((SegmentAllocator) a, parentWindow, frameSel);
+      final var cFrame = (MemorySegment) ObjC.MSG_SEND_GET_FRAME.invokeExact((SegmentAllocator) a, nsWindow, frameSel);
       final double pX = pFrame.get(JAVA_DOUBLE, 0);
       final double pY = pFrame.get(JAVA_DOUBLE, 8);
       final double pW = pFrame.get(JAVA_DOUBLE, 16);

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/ComController.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/ComController.java
@@ -17,6 +17,7 @@ final class ComController {
   private final MethodHandle moveFocus;
   private final MethodHandle close;
   private final MethodHandle getCoreWebView2;
+  private final MethodHandle putDefaultBgColor;
 
   /**
    * Binds all vtable method handles eagerly from the given {@code ICoreWebView2Controller} COM
@@ -31,6 +32,7 @@ final class ComController {
     moveFocus = Win32.resolve(ptr, 12, FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
     close = Win32.resolve(ptr, 24, FunctionDescriptor.of(JAVA_INT, ADDRESS));
     getCoreWebView2 = Win32.resolve(ptr, 25, FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+    putDefaultBgColor = Win32.resolve(ptr, 27, FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
   }
 
   /**
@@ -101,6 +103,20 @@ final class ComController {
       if (hr != 0)
         throw new RuntimeException("get_CoreWebView2 failed: 0x" + Integer.toHexString(hr));
       return pWv2.get(ADDRESS, 0);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Calls {@code ICoreWebView2Controller2::put_DefaultBackgroundColor}.
+   *
+   * <p>{@code color} is a packed {@code COREWEBVIEW2_COLOR} struct (A, R, G, B as bytes in
+   * little-endian order). Pass {@code 0} for fully transparent ({@code A=0,R=0,G=0,B=0}).
+   */
+  void putDefaultBackgroundColor(int color) {
+    try {
+      final var _ = (int) putDefaultBgColor.invokeExact(ptr, color);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32.java
@@ -69,6 +69,7 @@ final class Win32 {
   static final int WM_QUIT = 0x0012;
   static final int WM_ACTIVATE = 0x0006;
   static final int WM_GETMINMAXINFO = 0x0024;
+  static final int WM_MOVING = 0x0216;
   static final int WM_NCCALCSIZE = 0x0083;
   static final int WM_SETTINGCHANGE = 0x001A;
   static final int WM_APP = 0x8000;
@@ -79,6 +80,7 @@ final class Win32 {
   static final int SWP_NOZORDER = 0x0004;
   static final int SWP_NOACTIVATE = 0x0010;
   static final int SWP_FRAMECHANGED = 0x0020;
+  static final int WS_EX_NOREDIRECTBITMAP = 0x00200000;
   static final int WM_DPICHANGED = 0x02E0;
   static final int SM_CXSCREEN = 0;
   static final int SM_CYSCREEN = 1;

--- a/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
+++ b/avaje-webview/src/main/java/io/avaje/webview/windows/Win32WebView.java
@@ -131,6 +131,7 @@ public final class Win32WebView extends WebviewBase {
   private final ConcurrentLinkedQueue<Runnable> scriptDoneCallbacks = new ConcurrentLinkedQueue<>();
 
   private volatile int minW, minH, maxW, maxH;
+  private int parentOffsetX, parentOffsetY;
   private long navToken;
   private int currentDpi = Win32.DEFAULT_DPI;
 
@@ -170,8 +171,10 @@ public final class Win32WebView extends WebviewBase {
       int height,
       boolean borderless,
       boolean outline,
-      MemorySegment parentWindow) {
-    super(redirectConsole, borderless, outline, parentWindow);
+      boolean transparent,
+      MemorySegment parentWindow,
+      boolean moveParentWithChild) {
+    super(redirectConsole, borderless, outline, transparent, parentWindow, moveParentWithChild);
     Win32.coInitialize();
     Win32.enablePerMonitorDpiAwareness();
     buildWndProcStubs();
@@ -180,6 +183,18 @@ public final class Win32WebView extends WebviewBase {
     embedWebView2(debug);
     setSizeImpl(width, height);
     Win32.centerWindow(hwnd, this.parentWindow);
+    if (moveParentWithChild && this.parentWindow.address() != 0) {
+      try (var a = Arena.ofConfined()) {
+        final var cr = a.allocate(Win32.RECT_LAYOUT);
+        final var pr = a.allocate(Win32.RECT_LAYOUT);
+        final var _ = (int) Win32.GetWindowRect.invokeExact(hwnd, cr);
+        final var _ = (int) Win32.GetWindowRect.invokeExact(this.parentWindow, pr);
+        parentOffsetX = pr.get(JAVA_INT, 0) - cr.get(JAVA_INT, 0);
+        parentOffsetY = pr.get(JAVA_INT, 4) - cr.get(JAVA_INT, 4);
+      } catch (final Throwable t) {
+        throw new RuntimeException(t);
+      }
+    }
   }
 
   @Override
@@ -263,6 +278,31 @@ public final class Win32WebView extends WebviewBase {
   protected void setMaxSizeImpl(int width, int height) {
     maxW = width;
     maxH = height;
+  }
+
+  @Override
+  protected void disableMaximizeImpl() {
+    try {
+      final var style = (int) Win32.GetWindowLong.invokeExact(hwnd, Win32.GWL_STYLE);
+      final var _ =
+          (int) Win32.SetWindowLong.invokeExact(hwnd, Win32.GWL_STYLE, style & ~Win32.WS_MAXIMIZEBOX);
+      final var _ =
+          (int)
+              Win32.SetWindowPos.invokeExact(
+                  hwnd,
+                  MemorySegment.NULL,
+                  0,
+                  0,
+                  0,
+                  0,
+                  Win32.SWP_NOMOVE
+                      | Win32.SWP_NOSIZE
+                      | Win32.SWP_NOZORDER
+                      | Win32.SWP_NOACTIVATE
+                      | Win32.SWP_FRAMECHANGED);
+    } catch (final Throwable t) {
+      throw new RuntimeException(t);
+    }
   }
 
   @Override
@@ -476,6 +516,26 @@ public final class Win32WebView extends WebviewBase {
         }
         return 0;
       }
+      case Win32.WM_MOVING -> {
+        if (moveParentWithChild && parentWindow.address() != 0) {
+          final var r = MemorySegment.ofAddress(lParam).reinterpret(16);
+          final int newLeft = r.get(JAVA_INT, 0);
+          final int newTop = r.get(JAVA_INT, 4);
+          try {
+            final var _ =
+                (int)
+                    Win32.SetWindowPos.invokeExact(
+                        parentWindow,
+                        MemorySegment.NULL,
+                        newLeft + parentOffsetX,
+                        newTop + parentOffsetY,
+                        0,
+                        0,
+                        Win32.SWP_NOSIZE | Win32.SWP_NOZORDER | Win32.SWP_NOACTIVATE);
+          } catch (final Throwable ignored) {
+          }
+        }
+      }
       case Win32.WM_NCCALCSIZE -> {
         if (borderless && wParam == 1L) {
           if (outline) {
@@ -594,7 +654,7 @@ public final class Win32WebView extends WebviewBase {
       hwnd =
           (MemorySegment)
               Win32.CreateWindowExW.invokeExact(
-                  0,
+                  transparent ? Win32.WS_EX_NOREDIRECTBITMAP : 0,
                   a.allocateFrom(mainCls, StandardCharsets.UTF_16LE),
                   a.allocateFrom("", StandardCharsets.UTF_16LE),
                   Win32.WS_OVERLAPPEDWINDOW,
@@ -614,7 +674,9 @@ public final class Win32WebView extends WebviewBase {
       hwndWidget =
           (MemorySegment)
               Win32.CreateWindowExW.invokeExact(
-                  0x10000 /* WS_EX_CONTROLPARENT */,
+                  transparent
+                      ? (0x10000 | Win32.WS_EX_NOREDIRECTBITMAP) /* WS_EX_CONTROLPARENT */
+                      : 0x10000 /* WS_EX_CONTROLPARENT */,
                   a.allocateFrom(widgetCls, StandardCharsets.UTF_16LE),
                   MemorySegment.NULL,
                   Win32.WS_CHILD,
@@ -827,6 +889,7 @@ public final class Win32WebView extends WebviewBase {
   private void doInitTasks() {
     applySettings(debugMode);
     Win32.applyDarkMode(hwnd, isDarkTheme());
+    if (transparent) applyTransparency();
     setupJsBridge(POST_FN); // nativeAddUserScript uses nested pump; works from msgWndProc context
     resizeWidget(hwnd);
     try {
@@ -1028,6 +1091,10 @@ public final class Win32WebView extends WebviewBase {
     if (settings == null) return;
     settings.putIsStatusBarEnabled(false);
     settings.putAreDevToolsEnabled(debug);
+  }
+
+  private void applyTransparency() {
+    controller.putDefaultBackgroundColor(0);
   }
 
   private void resizeWidget(MemorySegment hWnd) {

--- a/examples/hello-world/src/main/java/ChildWindowExample.java
+++ b/examples/hello-world/src/main/java/ChildWindowExample.java
@@ -80,7 +80,7 @@ void main() {
 
   main.bind(
       "openChild",
-      req -> {
+      _ -> {
         // Build and run the child on its own platform thread - each Webview.run() blocks
         // its calling thread until that window closes, so the child needs its own thread
         // while the main window keeps pumping on this one.
@@ -92,8 +92,8 @@ void main() {
                           .title("Please wait")
                           .width(320)
                           .height(180)
-                          .parent(main) // disables `main` until this window closes
-                          .html(CHILD_HTML)
+                          .parent(main, true) // disables `main` until this window closes
+                          .html(CHILD_HTML).maximizable(false)
                           .build()) {
                     child.bind(
                         "closeDialog",

--- a/examples/hello-world/src/main/java/TransparentExample.java
+++ b/examples/hello-world/src/main/java/TransparentExample.java
@@ -20,7 +20,10 @@ String HTML =
     }
 
     .card {
-      background: transparent;
+      background: rgba(255,255,255,0.12);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border: 1px solid rgba(255,255,255,0.2);
       border-radius: 16px;
       padding: 32px 40px;
       color: #fff;

--- a/examples/hello-world/src/main/java/TransparentExample.java
+++ b/examples/hello-world/src/main/java/TransparentExample.java
@@ -1,0 +1,72 @@
+import io.avaje.webview.Webview;
+
+String HTML =
+"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      background: transparent;
+      font-family: system-ui, sans-serif;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      -webkit-app-region: drag;
+    }
+
+    .card {
+      background: transparent;
+      border-radius: 16px;
+      padding: 32px 40px;
+      color: #fff;
+      text-align: center;
+      -webkit-app-region: no-drag;
+    }
+
+    h1 { font-size: 1.6rem; font-weight: 600; margin-bottom: 8px; }
+    p  { opacity: 0.65; font-size: 0.95rem; }
+
+    button {
+      margin-top: 20px;
+      padding: 8px 20px;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.25);
+      background: rgba(255,255,255,0.1);
+      color: #fff;
+      cursor: pointer;
+      font-size: 0.9rem;
+    }
+    button:hover { background: rgba(255,255,255,0.2); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Transparent Window</h1>
+    <p>The desktop shows through the empty areas.<br>This card uses <code>backdrop-filter: blur</code>.</p>
+    <button onclick="closeApp()">Close</button>
+  </div>
+</body>
+</html>
+""";
+
+void main() {
+  Webview webview =
+      Webview.builder()
+          .width(420)
+          .height(240)
+          .borderless(true)
+          .transparent(true)
+          .resizable(false)
+          .html(HTML)
+          .build();
+
+  webview.bind("closeApp", req -> { webview.close(); return null; });
+
+  // needs JVM argument -XstartOnFirstThread on macOS
+  webview.run();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.avaje</groupId>
-        <artifactId>java11-oss</artifactId>
-        <version>5.2</version>
-    </parent>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.avaje</groupId>
+    <artifactId>java11-oss</artifactId>
+    <version>5.2</version>
+  </parent>
 
-    <groupId>io.avaje.webview</groupId>
-    <artifactId>avaje-webview-parent</artifactId>
-    <name>avaje-webview-parent</name>
-    <version>0.26</version>
-    <packaging>pom</packaging>
-    <scm>
-        <developerConnection>scm:git:git@github.com:avaje/avaje-webview.git</developerConnection>
-    </scm>
+  <groupId>io.avaje.webview</groupId>
+  <artifactId>avaje-webview-parent</artifactId>
+  <name>avaje-webview-parent</name>
+  <version>0.26</version>
+  <packaging>pom</packaging>
+  <scm>
+    <developerConnection>scm:git:git@github.com:avaje/avaje-webview.git</developerConnection>
+  </scm>
 
   <properties>
     <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-    <modules>
-        <module>avaje-webview</module>
-    </modules>
+  <modules>
+    <module>avaje-webview</module>
+  </modules>
 
   <profiles>
     <profile>
@@ -39,5 +39,5 @@
         <module>examples</module>
       </modules>
     </profile>
-   </profiles>
+  </profiles>
 </project>


### PR DESCRIPTION
  - Add `Webview.builder().transparent(true)` that makes the window background see-through wherever the page itself doesn't paint an opaque pixel, so a page with background: transparent (+ optional backdrop-filter: blur) shows the desktop
  through it. 
  - Add .`maximizable(false)` to hide/disable the native maximize button (Windows + macOS).
  - Add `.minSize(w, h)` / `.maxSize(w, h) `builder options
  - Add `.parent(parent, moveParentWithChild)` overload. When true, dragging the child keeps the parent locked to it at a
  fixed offset (Windows + macOS).